### PR TITLE
make angular-output-target work with angular production builds

### DIFF
--- a/packages/angular-output-target/src/generate-angular-utils.ts
+++ b/packages/angular-output-target/src/generate-angular-utils.ts
@@ -11,14 +11,18 @@ export default async function generateAngularUtils(compilerCtx: CompilerCtx, out
 
 const PROXY_UTILS = `import { fromEvent } from 'rxjs';
 
-export function proxyInputs(Cmp: any, inputs: string[]) {
-  const Prototype = Cmp.prototype;
-  inputs.forEach(item => {
-    Object.defineProperty(Prototype, item, {
-      get() { return this.el[item]; },
-      set(val: any) { this.el[item] = val; },
+export function ProxyInputs(inputs: string[]) {
+  const decorator = function <T extends {new(...args:any[])}>(constructor:T) {
+    const Prototype = constructor.prototype;
+    inputs.forEach((item) => {
+      Object.defineProperty(Prototype, item, {
+        get() { return this.el[item]; },
+        set(val: any) { this.el[item] = val; },
+      });
     });
-  });
+    return constructor;
+  };
+  return decorator;
 }
 
 export function proxyMethods(Cmp: any, methods: string[]) {

--- a/packages/angular-output-target/src/generate-proxies.ts
+++ b/packages/angular-output-target/src/generate-proxies.ts
@@ -60,14 +60,14 @@ function getProxy(cmpMeta: ComponentCompilerMeta) {
   }
 
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
-  const lines = [`export declare interface ${tagNameAsPascal} extends Components.${tagNameAsPascal} {}`];
+  const lines = [`
+export declare interface ${tagNameAsPascal} extends Components.${tagNameAsPascal} {}`];
 
   if (hasInputs) {
     lines.push(`@ProxyInputs(['${inputs.join(`', '`)}'])`);
   }
 
-  lines.push(`
-@Component({ ${directiveOpts.join(', ')} })
+  lines.push(`@Component({ ${directiveOpts.join(', ')} })
 export class ${tagNameAsPascal} {`);
 
   // Generate outputs


### PR DESCRIPTION
If the angular wrappers are included in an angular application compiled with aot and buildOptimizer, the buildOptimizer will remove the proxyInputs logic since it's not really part of component. It just thinks it's unused code and tries to make the bundle as small as possible.
To prevent the code from getting removed the proxy inputs can be added via ts class annotation. Those are untouched by the build optimizer, as long as they annotate a component class.