### PR TITLE
Fix Jest Types Version and linting

### DIFF
--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@angular/core": "^7.2.15",
     "@angular/forms": "^7.2.15",
-    "@types/jest": "^24.0.11",
+    "@types/jest": "24.0.19",
     "jest": "^24.5.0",
     "np": "^4.0.2",
     "rimraf": "^2.6.3",

--- a/packages/react-output-target/package.json
+++ b/packages/react-output-target/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/ionic-team/stencil-ds-plugins/issues"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.11",
+    "@types/jest": "24.0.19",
     "@types/react": "^16.7.0",
     "@types/react-dom": "^16.7.0",
     "jest": "^24.5.0",

--- a/packages/react-output-target/src/output-react.ts
+++ b/packages/react-output-target/src/output-react.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { OutputTargetReact } from './types';
-import { dashToPascalCase, readPackageJson, relativeImport, sortBy, normalizePath } from './utils';
+import { dashToPascalCase, normalizePath, readPackageJson, relativeImport, sortBy } from './utils';
 import { CompilerCtx, ComponentCompilerMeta, Config } from '@stencil/core/internal';
 
 export async function reactProxyOutput(


### PR DESCRIPTION
Trying to build the project I was faced with 2 issues:


1. Linting Error:
```
> tslint --project tsconfig.json


ERROR: /Users/aharris/open-source/stencil-ds-plugins/packages/react-output-target/src/output-react.ts:3:61 - Named imports must be alphabetized.
```

2. Incompatible minor version of `@types/jest`

```
> tsc && npm run rollup

../../node_modules/@stencil/core/dist/declarations/testing.d.ts(4,19): error TS2428: All declarations of 'Matchers' must have identical type parameters.
node_modules/@types/jest/index.d.ts(729,15): error TS2428: All declarations of 'Matchers' must have identical type parameters.
```

Reverting from `24.0.23` to `24.0.19` resolves this issue:



This PR resolves both of these issue to allow running `npm run build` 