### PR TITLE
Add 'outputs' to generated proxies.

### DIFF
--- a/packages/angular-output-target/src/generate-proxies.ts
+++ b/packages/angular-output-target/src/generate-proxies.ts
@@ -58,6 +58,9 @@ function getProxy(cmpMeta: ComponentCompilerMeta) {
   if (inputs.length > 0) {
     directiveOpts.push(`inputs: ['${inputs.join(`', '`)}']`);
   }
+  if (outputs.length > 0) {
+    directiveOpts.push(`outputs: ['${outputs.join(`', '`)}']`)
+  }
 
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
   const lines = [`


### PR DESCRIPTION
Add 'outputs' to generated proxies so autocompletion works for events.