### PR TITLE
Angular: Add 'outputs' declaration

### DIFF
--- a/packages/angular-output-target/src/generate-proxies.ts
+++ b/packages/angular-output-target/src/generate-proxies.ts
@@ -70,6 +70,9 @@ function getProxy(cmpMeta: ComponentCompilerMeta) {
   if (inputs.length > 0) {
     directiveOpts.push(`inputs: ['${inputs.join(`', '`)}']`);
   }
+  if (outputs.length > 0) {
+    directiveOpts.push(`outputs: ['${outputs.join(`', '`)}']`);
+  }
 
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
   const lines = [`

--- a/packages/angular-output-target/src/generate-value-accessors.ts
+++ b/packages/angular-output-target/src/generate-value-accessors.ts
@@ -62,7 +62,7 @@ async function writeValueAccessor(type: ValueAccessorTypes, valueAccessor: Value
 
   const finalText = srcFileContents
     .replace(VALUE_ACCESSOR_SELECTORS, valueAccessor.elementSelectors.join(', '))
-    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join('\n'));
+    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join(',\n'));
 
   await compilerCtx.fs.writeFile(targetFilePath, finalText);
 }


### PR DESCRIPTION
This change will add the events which are emitted by the Stencil component, as outputs to the Angular `@Component` decorator.

This will improve the code completion within the target Angular application:
![code-completion](https://user-images.githubusercontent.com/3673890/76966207-e4b51300-6925-11ea-8d47-ea0e61ac92ee.png)