### PR TITLE
feat(angular-output-target): implement setDisabledState in ValueAccessor

### DIFF
--- a/packages/angular-output-target/resources/control-value-accessors/value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors/value-accessor.ts
@@ -33,6 +33,6 @@ export class ValueAccessor implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean) {
-    this.el.nativeElement.disabled = isDisabled
+    this.el.nativeElement.disabled = isDisabled;
   }
 }

--- a/packages/angular-output-target/resources/control-value-accessors/value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors/value-accessor.ts
@@ -31,4 +31,8 @@ export class ValueAccessor implements ControlValueAccessor {
   registerOnTouched(fn: () => void) {
     this.onTouched = fn;
   }
+
+  setDisabledState(isDisabled: boolean) {
+    this.el.nativeElement.disabled = isDisabled
+  }
 }

--- a/packages/example-project/component-library-angular/__tests__/my-input.spec.ts
+++ b/packages/example-project/component-library-angular/__tests__/my-input.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture } from '@angular/core/testing';
 
 import { ConfigureFn, configureTests } from '../src/config.testing';
 import { DebugElement, Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { ComponentLibraryModule } from '../src/index';
 
@@ -89,5 +89,44 @@ describe('MyInput - Number Value', () => {
     myInputEl.nativeElement.value = 50;
     myInputEl.nativeElement.dispatchEvent(new CustomEvent('myInput', { detail: { value: 50 } }));
     expect(myAngularComponent.testNumber).toEqual(50);
+  });
+});
+
+@Component({
+  template: `<form [formGroup]="form">
+    <my-input type="text" formControlName="test"></my-input>
+  </form>`,
+})
+class TestDisabledValueAccessorComponent {
+  form = this.formBuilder.group({
+    // disabled state will be managed for us by angular
+    // and now we can later call `this.form.controls.test.enable()`
+    test: this.formBuilder.control({ value: 'test', disabled: true }),
+  });
+
+  constructor(private formBuilder: FormBuilder) {}
+}
+
+describe('MyInput - Disabled state', () => {
+  let myInputEl: DebugElement;
+  let fixture: ComponentFixture<TestDisabledValueAccessorComponent>;
+
+  beforeEach(async(() => {
+    const configure: ConfigureFn = (testBed) => {
+      testBed.configureTestingModule({
+        imports: [ReactiveFormsModule, FormsModule, ComponentLibraryModule],
+        declarations: [TestDisabledValueAccessorComponent],
+      });
+    };
+
+    configureTests(configure).then((testBed) => {
+      fixture = testBed.createComponent(TestDisabledValueAccessorComponent);
+      fixture.detectChanges();
+      myInputEl = fixture.debugElement.query(By.css('my-input'));
+    });
+  }));
+
+  it('should support setting disabled state via the ValueAccessor', () => {
+    expect(myInputEl.nativeElement.disabled).toBe(true);
   });
 });

--- a/packages/example-project/component-library-angular/src/directives/proxies.ts
+++ b/packages/example-project/component-library-angular/src/directives/proxies.ts
@@ -1,9 +1,9 @@
 /* tslint:disable */
 /* auto-generated angular directive proxies */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, NgZone } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 
-import { Components } from 'component-library'
+import { Components } from 'component-library';
 
 import { Button as IButton } from 'component-library/dist/types/components/my-button/my-button';
 export declare interface MyButton extends Components.MyButton {}

--- a/packages/example-project/component-library-angular/src/directives/value-accessor.ts
+++ b/packages/example-project/component-library-angular/src/directives/value-accessor.ts
@@ -31,4 +31,8 @@ export class ValueAccessor implements ControlValueAccessor {
   registerOnTouched(fn: () => void) {
     this.onTouched = fn;
   }
+
+  setDisabledState(isDisabled: boolean) {
+    this.el.nativeElement.disabled = isDisabled;
+  }
 }


### PR DESCRIPTION
The base ValueAccessor for the angular-output-target did not implement [setDisabledState](https://angular.io/api/forms/ControlValueAccessor#setDisabledState). This meant that `disabled` prop of components could not be set/managed through `FormControl`s.

By adding setDisabledState, this will now work:

`app.component.ts`:
```ts
import { Component } from "@angular/core";
import { FormBuilder } from "@angular/forms";

@Component({
  selector: "app-root",
  templateUrl: "./app.component.html",
  styleUrls: ["./app.component.css"],
})
export class AppComponent {
  form = this.formBuilder.group({
	// disabled state will be managed for us by angular
	// and now we can later call `this.form.controls.firstName.enable()`
    firstName: this.formBuilder.control({ value: "", disabled: true }),
    lastName: "",
  });

  constructor(private formBuilder: FormBuilder) {}
}

```

`app.component.html`:
```html
<form [formGroup]="form">
  <my-stencil-input formControlName="firstName" label="First name"> </my-stencil-input>
  <my-stencil-input formControlName="lastName" label="Last name"> </my-stencil-input>

  <button type="submit">Submit</button>
</form>
```