### PR TITLE
Fix possible `null` value in attachEventProps

### DIFF
--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -29,7 +29,7 @@ export const createReactComponent = <PropType, ElementType>(tagName: string) => 
 
     componentDidUpdate(prevProps: IonicReactInternalProps<ElementType>) {
       const node = this.ref.current;
-      attachEventProps(node, this.props, prevProps);
+      node && attachEventProps(node, this.props, prevProps);
     }
 
     render() {


### PR DESCRIPTION
`this.ref.current` is possibly `null`. Adding a short-circuit prevents passing `null` to `attachEventProps`.