### PR TITLE
transformTagName compatibility

### DIFF
--- a/packages/angular-output-target/src/generate-proxies.ts
+++ b/packages/angular-output-target/src/generate-proxies.ts
@@ -63,7 +63,7 @@ function getProxy(cmpMeta: ComponentCompilerMeta) {
 
   // Generate Angular @Directive
   const directiveOpts = [
-    `selector: \'${cmpMeta.tagName}\'`,
+    `selector: \'${cmpMeta.tagName}, [${cmpMeta.tagName}]\'`,
     `changeDetection: ChangeDetectionStrategy.OnPush`,
     `template: '<ng-content></ng-content>'`
   ];

--- a/packages/example-project/component-library-angular/src/directives/proxies.ts
+++ b/packages/example-project/component-library-angular/src/directives/proxies.ts
@@ -45,7 +45,7 @@ import { Components } from 'component-library'
 
 export declare interface MyButton extends Components.MyButton {}
 @ProxyCmp({inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type']})
-@Component({ selector: 'my-button', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type'] })
+@Component({ selector: 'my-button, [my-button]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type'] })
 export class MyButton {
   myFocus!: EventEmitter<CustomEvent>;
   myBlur!: EventEmitter<CustomEvent>;
@@ -59,7 +59,7 @@ export class MyButton {
 
 export declare interface MyCheckbox extends Components.MyCheckbox {}
 @ProxyCmp({inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value']})
-@Component({ selector: 'my-checkbox', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value'] })
+@Component({ selector: 'my-checkbox, [my-checkbox]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value'] })
 export class MyCheckbox {
   myChange!: EventEmitter<CustomEvent>;
   myFocus!: EventEmitter<CustomEvent>;
@@ -74,7 +74,7 @@ export class MyCheckbox {
 
 export declare interface MyComponent extends Components.MyComponent {}
 @ProxyCmp({inputs: ['age', 'first', 'kidsNames', 'last', 'middle']})
-@Component({ selector: 'my-component', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['age', 'first', 'kidsNames', 'last', 'middle'] })
+@Component({ selector: 'my-component, [my-component]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['age', 'first', 'kidsNames', 'last', 'middle'] })
 export class MyComponent {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
@@ -85,7 +85,7 @@ export class MyComponent {
 
 export declare interface MyInput extends Components.MyInput {}
 @ProxyCmp({inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'], 'methods': ['setFocus', 'getInputElement']})
-@Component({ selector: 'my-input', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'] })
+@Component({ selector: 'my-input, [my-input]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'] })
 export class MyInput {
   myInput!: EventEmitter<CustomEvent>;
   myChange!: EventEmitter<CustomEvent>;
@@ -101,7 +101,7 @@ export class MyInput {
 
 export declare interface MyPopover extends Components.MyPopover {}
 @ProxyCmp({inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'], 'methods': ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']})
-@Component({ selector: 'my-popover', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'] })
+@Component({ selector: 'my-popover, [my-popover]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'] })
 export class MyPopover {
   myPopoverDidPresent!: EventEmitter<CustomEvent>;
   myPopoverWillPresent!: EventEmitter<CustomEvent>;
@@ -117,7 +117,7 @@ export class MyPopover {
 
 export declare interface MyRadio extends Components.MyRadio {}
 @ProxyCmp({inputs: ['color', 'disabled', 'mode', 'name', 'value']})
-@Component({ selector: 'my-radio', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['color', 'disabled', 'mode', 'name', 'value'] })
+@Component({ selector: 'my-radio, [my-radio]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['color', 'disabled', 'mode', 'name', 'value'] })
 export class MyRadio {
   myFocus!: EventEmitter<CustomEvent>;
   myBlur!: EventEmitter<CustomEvent>;
@@ -131,7 +131,7 @@ export class MyRadio {
 
 export declare interface MyRadioGroup extends Components.MyRadioGroup {}
 @ProxyCmp({inputs: ['allowEmptySelection', 'name', 'value']})
-@Component({ selector: 'my-radio-group', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['allowEmptySelection', 'name', 'value'] })
+@Component({ selector: 'my-radio-group, [my-radio-group]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['allowEmptySelection', 'name', 'value'] })
 export class MyRadioGroup {
   myChange!: EventEmitter<CustomEvent>;
   protected el: HTMLElement;
@@ -144,7 +144,7 @@ export class MyRadioGroup {
 
 export declare interface MyRange extends Components.MyRange {}
 @ProxyCmp({inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value']})
-@Component({ selector: 'my-range', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value'] })
+@Component({ selector: 'my-range, [my-range]', changeDetection: ChangeDetectionStrategy.OnPush, template: '<ng-content></ng-content>', inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value'] })
 export class MyRange {
   myChange!: EventEmitter<CustomEvent>;
   myFocus!: EventEmitter<CustomEvent>;

--- a/packages/example-project/component-library-react/src/components-provider.ts
+++ b/packages/example-project/component-library-react/src/components-provider.ts
@@ -1,0 +1,29 @@
+/* eslint-disable */
+/* tslint:disable */
+/* auto-generated react proxies */
+import { createReactComponent } from './react-component-lib';
+
+import { JSX } from 'component-library';
+
+export function componentsFactory(transformTagName: (tagName: string) => string = tagName => tagName) {
+  return {
+    MyButton: /*@__PURE__*/createReactComponent<JSX.MyButton, HTMLMyButtonElement>(transformTagName('my-button')),
+    MyCheckbox: /*@__PURE__*/createReactComponent<JSX.MyCheckbox, HTMLMyCheckboxElement>(transformTagName('my-checkbox')),
+    MyComponent: /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>(transformTagName('my-component')),
+    MyInput: /*@__PURE__*/createReactComponent<JSX.MyInput, HTMLMyInputElement>(transformTagName('my-input')),
+    MyPopover: /*@__PURE__*/createReactComponent<JSX.MyPopover, HTMLMyPopoverElement>(transformTagName('my-popover')),
+    MyRadio: /*@__PURE__*/createReactComponent<JSX.MyRadio, HTMLMyRadioElement>(transformTagName('my-radio')),
+    MyRadioGroup: /*@__PURE__*/createReactComponent<JSX.MyRadioGroup, HTMLMyRadioGroupElement>(transformTagName('my-radio-group')),
+    MyRange: /*@__PURE__*/createReactComponent<JSX.MyRange, HTMLMyRangeElement>(transformTagName('my-range'))
+  };
+}
+
+const components = componentsFactory();
+export const MyButton = components.MyButton;
+export const MyCheckbox = components.MyCheckbox;
+export const MyComponent = components.MyComponent;
+export const MyInput = components.MyInput;
+export const MyPopover = components.MyPopover;
+export const MyRadio = components.MyRadio;
+export const MyRadioGroup = components.MyRadioGroup;
+export const MyRange = components.MyRange;

--- a/packages/example-project/component-library-react/src/components.ts
+++ b/packages/example-project/component-library-react/src/components.ts
@@ -1,18 +1,8 @@
 /* eslint-disable */
 /* tslint:disable */
 /* auto-generated react proxies */
-import { createReactComponent } from './react-component-lib';
-
-import { JSX } from 'component-library';
-
 import { defineCustomElements, applyPolyfills } from 'component-library/loader';
 
+export * from './components-provider';
+
 applyPolyfills().then(() => defineCustomElements());
-export const MyButton = /*@__PURE__*/createReactComponent<JSX.MyButton, HTMLMyButtonElement>('my-button');
-export const MyCheckbox = /*@__PURE__*/createReactComponent<JSX.MyCheckbox, HTMLMyCheckboxElement>('my-checkbox');
-export const MyComponent = /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>('my-component');
-export const MyInput = /*@__PURE__*/createReactComponent<JSX.MyInput, HTMLMyInputElement>('my-input');
-export const MyPopover = /*@__PURE__*/createReactComponent<JSX.MyPopover, HTMLMyPopoverElement>('my-popover');
-export const MyRadio = /*@__PURE__*/createReactComponent<JSX.MyRadio, HTMLMyRadioElement>('my-radio');
-export const MyRadioGroup = /*@__PURE__*/createReactComponent<JSX.MyRadioGroup, HTMLMyRadioGroupElement>('my-radio-group');
-export const MyRange = /*@__PURE__*/createReactComponent<JSX.MyRange, HTMLMyRangeElement>('my-range');


### PR DESCRIPTION
Changes the wrappers to be compatible to changed tag names via `transformTagName` option.
```
defineCustomElements(window, {
    transformTagName: function() {
      return 'my-prefixed-' + tagName;
    }
  });
```
* For Angular: Provides an attribute selector, that there is no specific tag name required, as long as the attribute selector is used (changing tag name at runtime is not possible, is it?)
```
<my-prefixed-my-button my-button [someProxiedInput]="theValue">Some content</my-prefixed-my-button>
```
* For React: Provides a additional factory function, that can receive a `transformTagName` callback to dynamically change the rendered tag name
```
const { MyButton: MyPrefixedMyButton } = componentsFactory((tagName: string) => {
    return `my-prefixed-${tagName}`;
  });
<MyPrefixedMyButton>Some content</MyPrefixedMyButton> // renders to <my-prefixed-my-button>Some content</my-prefixed-my-button>
```