### PR TITLE
Add ability to skip polyfills and registration.

### DIFF
--- a/packages/react-output-target/__tests__/generate-react-components.spec.ts
+++ b/packages/react-output-target/__tests__/generate-react-components.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentCompilerMeta } from '@stencil/core/internal';
+import { generateProxies } from '../src/output-react';
+import { PackageJSON, OutputTargetReact } from '../src/types';
+
+describe('generateProxies', () => {
+  const components: ComponentCompilerMeta[] = [];
+  const pkgData: PackageJSON = {
+    types: 'dist/types/index.d.ts',
+  };
+  const rootDir: string = '';
+  beforeEach(() => {});
+
+  it('should include both polyfills and definCustomElements when both are true in the outputTarget', () => {
+    const outputTarget: OutputTargetReact = {
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-react/src/proxies.ts',
+      includePolyfills: true,
+      includeDefineCustomElements: true,
+    };
+
+    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    expect(finalText).toEqual(
+      `/* eslint-disable */
+/* tslint:disable */
+/* auto-generated react proxies */
+import { createReactComponent } from './react-component-lib';
+
+import { JSX } from 'component-library';
+
+import { applyPolyfills, defineCustomElements } from 'component-library/loader';
+
+applyPolyfills().then(() => defineCustomElements());
+
+`,
+    );
+  });
+
+  it('should include only defineCustomElements when includePolyfills is false in the outputTarget', () => {
+    const outputTarget: OutputTargetReact = {
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-react/src/proxies.ts',
+      includePolyfills: false,
+      includeDefineCustomElements: true,
+    };
+
+    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    expect(finalText).toEqual(
+      `/* eslint-disable */
+/* tslint:disable */
+/* auto-generated react proxies */
+import { createReactComponent } from './react-component-lib';
+
+import { JSX } from 'component-library';
+
+import { defineCustomElements } from 'component-library/loader';
+
+defineCustomElements();
+
+`,
+    );
+  });
+
+  it('should not include defineCustomElements or applyPolyfills if both are false in the outputTarget', () => {
+    const outputTarget: OutputTargetReact = {
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-react/src/proxies.ts',
+      includePolyfills: false,
+      includeDefineCustomElements: false,
+    };
+
+    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    expect(finalText).toEqual(
+      `/* eslint-disable */
+/* tslint:disable */
+/* auto-generated react proxies */
+import { createReactComponent } from './react-component-lib';
+
+import { JSX } from 'component-library';
+
+
+
+
+`,
+    );
+  });
+});

--- a/packages/react-output-target/package.json
+++ b/packages/react-output-target/package.json
@@ -19,8 +19,7 @@
     "rollup": "rollup -c",
     "version": "npm run build",
     "release": "np",
-    "test": "jest --passWithNoTests",
-    "test.watch": "jest --watch"
+    "test": "../../node_modules/.bin/jest"
   },
   "repository": {
     "type": "git",

--- a/packages/react-output-target/src/plugin.ts
+++ b/packages/react-output-target/src/plugin.ts
@@ -16,14 +16,15 @@ export const reactOutputTarget = (outputTarget: OutputTargetReact): OutputTarget
     await reactProxyOutput(compilerCtx, outputTarget, buildCtx.components, config);
 
     timespan.finish(`generate react finished`);
-  }
+  },
 });
-
 
 function normalizeOutputTarget(config: Config, outputTarget: any) {
   const results: OutputTargetReact = {
     ...outputTarget,
-    excludeComponents: outputTarget.excludeComponents || []
+    excludeComponents: outputTarget.excludeComponents || [],
+    includePolyfills: outputTarget.includePolyfills ?? true,
+    includeDefineCustomElements: outputTarget.includeDefineCustomElements ?? true,
   };
 
   if (config.rootDir == null) {

--- a/packages/react-output-target/src/types.ts
+++ b/packages/react-output-target/src/types.ts
@@ -3,6 +3,8 @@ export interface OutputTargetReact {
   proxiesFile: string;
   excludeComponents?: string[];
   loaderDir?: string;
+  includePolyfills?: boolean;
+  includeDefineCustomElements?: boolean;
 }
 
 export interface PackageJSON {

--- a/packages/vue-output-target/__tests__/generate-vue-compontes.spec.ts
+++ b/packages/vue-output-target/__tests__/generate-vue-compontes.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentCompilerMeta } from '@stencil/core/internal';
+import { generateProxies } from '../src/output-vue';
+import { PackageJSON, OutputTargetVue } from '../src/types';
+
+describe('generateProxies', () => {
+  const components: ComponentCompilerMeta[] = [];
+  const pkgData: PackageJSON = {
+    types: 'dist/types/index.d.ts',
+  };
+  const rootDir: string = '';
+  beforeEach(() => {});
+
+  it('should include both polyfills and definCustomElements when both are true in the outputTarget', () => {
+    const outputTarget: OutputTargetVue = {
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-vue/src/proxies.ts',
+      includePolyfills: true,
+      includeDefineCustomElements: true,
+    };
+
+    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    expect(finalText).toEqual(
+      `/* eslint-disable */
+/* tslint:disable */
+/* auto-generated vue proxies */
+import Vue, { PropOptions } from 'vue';
+import { createCommonRender, createCommonMethod } from './vue-component-lib/utils';
+
+import { Components } from 'component-library';
+
+import { applyPolyfills, defineCustomElements } from 'component-library/loader';
+
+applyPolyfills().then(() => defineCustomElements());
+
+const customElementTags: string[] = [
+
+];
+Vue.config.ignoredElements = [...Vue.config.ignoredElements, ...customElementTags];
+
+
+`,
+    );
+  });
+
+  it('should include only defineCustomElements when includePolyfills is false in the outputTarget', () => {
+    const outputTarget: OutputTargetVue = {
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-vue/src/proxies.ts',
+      includePolyfills: false,
+      includeDefineCustomElements: true,
+    };
+
+    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    expect(finalText).toEqual(
+      `/* eslint-disable */
+/* tslint:disable */
+/* auto-generated vue proxies */
+import Vue, { PropOptions } from 'vue';
+import { createCommonRender, createCommonMethod } from './vue-component-lib/utils';
+
+import { Components } from 'component-library';
+
+import { defineCustomElements } from 'component-library/loader';
+
+defineCustomElements();
+
+const customElementTags: string[] = [
+
+];
+Vue.config.ignoredElements = [...Vue.config.ignoredElements, ...customElementTags];
+
+
+`,
+    );
+  });
+
+  it('should not include defineCustomElements or applyPolyfills if both are false in the outputTarget', () => {
+    const outputTarget: OutputTargetVue = {
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-vue/src/proxies.ts',
+      includePolyfills: false,
+      includeDefineCustomElements: false,
+    };
+
+    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    expect(finalText).toEqual(
+      `/* eslint-disable */
+/* tslint:disable */
+/* auto-generated vue proxies */
+import Vue, { PropOptions } from 'vue';
+import { createCommonRender, createCommonMethod } from './vue-component-lib/utils';
+
+import { Components } from 'component-library';
+
+
+
+
+const customElementTags: string[] = [
+
+];
+Vue.config.ignoredElements = [...Vue.config.ignoredElements, ...customElementTags];
+
+
+`,
+    );
+  });
+});

--- a/packages/vue-output-target/package.json
+++ b/packages/vue-output-target/package.json
@@ -19,8 +19,7 @@
     "rollup": "rollup -c",
     "version": "npm run build",
     "release": "np",
-    "test": "jest --passWithNoTests",
-    "test.watch": "jest --watch"
+    "test": "../../node_modules/.bin/jest"
   },
   "repository": {
     "type": "git",

--- a/packages/vue-output-target/src/plugin.ts
+++ b/packages/vue-output-target/src/plugin.ts
@@ -24,6 +24,8 @@ function normalizeOutputTarget(config: Config, outputTarget: any) {
     ...outputTarget,
     excludeComponents: outputTarget.excludeComponents || [],
     componentModels: outputTarget.componentModels || [],
+    includePolyfills: outputTarget.includePolyfills ?? true,
+    includeDefineCustomElements: outputTarget.includeDefineCustomElements ?? true,
   };
 
   if (config.rootDir == null) {

--- a/packages/vue-output-target/src/types.ts
+++ b/packages/vue-output-target/src/types.ts
@@ -4,6 +4,8 @@ export interface OutputTargetVue {
   excludeComponents?: string[];
   componentModels?: ComponentModelConfig[];
   loaderDir?: string;
+  includePolyfills?: boolean;
+  includeDefineCustomElements?: boolean;
 }
 
 export interface ComponentModelConfig {


### PR DESCRIPTION
This PR adds more functionality to the React and Vue output targets. You will be able to turn on and off polyfills and defineCustomElements based on stencil.config.ts settings.