### PR TITLE
fix(#81): add blank event-emitter

### DIFF
--- a/packages/angular-output-target/angular-component-lib/utils.ts
+++ b/packages/angular-output-target/angular-component-lib/utils.ts
@@ -1,4 +1,4 @@
-import { fromEvent } from 'rxjs';
+import { EventEmitter } from '@angular/core';
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
@@ -25,7 +25,7 @@ export const proxyMethods = (Cmp: any, methods: string[]) => {
 };
 
 export const proxyOutputs = (instance: any, el: any, events: string[]) => {
-  events.forEach((eventName) => (instance[eventName] = fromEvent(el, eventName)));
+  events.forEach((eventName) => (instance[eventName] = new EventEmitter()));
 };
 
 // tslint:disable-next-line: only-arrow-functions


### PR DESCRIPTION
Since the events are added to the outputs array - there's no need to create an observable listener anymore to bubble the events. Instead - to keep the outputs array and the types, `fromEvent` can be replaced with an empty `EventEmitter` in the angular proxy utils.

```diff
export const proxyOutputs = (instance: any, el: any, events: string[]) => {
--  events.forEach((eventName) => (instance[eventName] = fromEvent(el, eventName)));
++  events.forEach((eventName) => (instance[eventName] = new EventEmitter()));
};
```