### PR TITLE
fix(react-output-target): render React props in initial render for SSR

### DIFF
--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -57,6 +57,8 @@ export const createReactComponent = <
           if (isCoveredByReact(eventName)) {
             (acc as any)[name] = (cProps as any)[name];
           }
+        } else {
+          (acc as any)[name] = (cProps as any)[name];
         }
         return acc;
       }, {});


### PR DESCRIPTION
Thanks for the awesome library. I'm currently exploring the use of Stencil.js for a framework-agnostic Design System. I discovered this issue when testing Stencil.js with `react-output-target` and Next.js using SSR.

## Problem

Stencil.js works great for SSR, but the `react-output-target` package misbehaves.

### Expected behaviour

Given this Stencil component

```jsx
import { Component, h, Prop } from '@stencil/core';

@Component({
  tag: 'my-burger'
})
export class MyBurger {
  @Prop() cheese: string = '';

  render() {
    const cheeseClass = this.cheese ? ` burger--${this.cheese}-cheese` : '';

    return (
      <div class={'burger' + cheeseClass}>
        <slot />
      </div>
    );
  }
}
```

And this React markup

```jsx
<MyBurger cheese="american">
  Patty
</MyBurger> 
```

Stencil.js `renderToString()` should produce

```html
<my-burger cheese="american">
  <div class="burger burger--american-cheese">
    Patty
  </div>
</my-burger>
```

### Actual behaviour

`renderToString()` produces

```html
<my-burger>
  <div class="burger">
    Patty
  </div>
</my-burger>
```

This is because the attributes aren't written to the element [until the component is mounted](https://github.com/chrisvxd/stencil-ds-output-targets/blob/master/packages/react-output-target/react-component-lib/createComponent.tsx#L48) via the ref in the `componentDidMount` and `componentDidUpdate` methods (which aren't called on server).

## Solution

Render all properties during the initial `render()`, and pass to `React.createElement`. Now `renderToString()` renders correctly:

```html
<my-burger cheese="american">
  <div class="burger burger--american-cheese">
    Patty
  </div>
</my-burger>
```

Looking forward to your review 🙏