### PR TITLE
add angular-component-lib to published package

### DIFF
--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/",
-    "resources/"
+    "resources/",
+    "angular-component-lib/"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
As discussed on slack, `@stencil/angular-output-target@0.0.4` is missing the `angular-component-lib` folder, which is required to build the output. This PR adds `angular-component-lib` to the `files` field of the package.json