### PR TITLE
Vue: Allow empty string values in common render proxy events

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -8,7 +8,7 @@ export const createCommonRender = (tagName: string, eventNames: string[] = []) =
         ...listeners,
         [eventName]: (event: CustomEvent<any>) => {
           let emittedValue = event.detail;
-          if (event.detail?.value) {
+          if (event.detail?.value != null) {
             emittedValue = event.detail.value;
           }
           vueElement.$emit(eventName, emittedValue);


### PR DESCRIPTION
Currently, when using Vue's `v-model` on an input, deleting all input's content at once will get you `[object Object]`. This PR should fix that.

![image](https://user-images.githubusercontent.com/851105/90729301-a94cb500-e2c6-11ea-8b9a-3422d4b5b7f6.png)
