### PR TITLE
Added Empty Directive Decorator

### DIFF
--- a/packages/angular-output-target/resources/control-value-accessors/value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors/value-accessor.ts
@@ -1,6 +1,7 @@
-import { ElementRef, HostListener } from '@angular/core';
+import { Directive, ElementRef, HostListener } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 
+@Directive({})
 export class ValueAccessor implements ControlValueAccessor {
 
   private onChange: (value: any) => void = () => {/**/};


### PR DESCRIPTION
Build of component-library-angular is failing with angular 10. This PR fixes it by adding Empty Directive Decorator to value-accessor.ts.