### PR TITLE
Removed outputs in angular component decorator

### DIFF
--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -27,9 +27,6 @@ export const createComponentDefinition = (
   if (inputs.length > 0) {
     directiveOpts.push(`inputs: ['${inputs.join(`', '`)}']`);
   }
-  if (outputs.length > 0) {
-    directiveOpts.push(`outputs: ['${outputs.map((output) => output.name).join(`', '`)}']`);
-  }
 
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
 


### PR DESCRIPTION
Removing the outputs attribute in the component decorator removes the issue with events emitting twice.