### PR TITLE
Use JSX to create component

### DIFF
--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -76,7 +76,7 @@ export const createReactComponent = <
         style,
       };
 
-      return React.createElement(tagName, newProps, children);
+      return <ReactComponent {...newProps}>{children}</ReactComponent>;
     }
 
     static get displayName() {


### PR DESCRIPTION
This delegates JSX compilation to TypeScript, which can then transform it either to [`React.createElement` or `_jsx` call](https://www.typescriptlang.org/tsconfig#jsx).