### PR TITLE
fix(react): Ignore undefined property values

### DIFF
--- a/packages/example-project/component-library-react/src/react-component-lib/utils/attachProps.ts
+++ b/packages/example-project/component-library-react/src/react-component-lib/utils/attachProps.ts
@@ -16,7 +16,8 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
         name === 'ref' ||
         name === 'class' ||
         name === 'className' ||
-        name === 'forwardedRef'
+        name === 'forwardedRef' ||
+        newProps[name] === undefined
       ) {
         return;
       }

--- a/packages/react-output-target/react-component-lib/utils/attachProps.ts
+++ b/packages/react-output-target/react-component-lib/utils/attachProps.ts
@@ -16,7 +16,8 @@ export const attachProps = (node: HTMLElement, newProps: any, oldProps: any = {}
         name === 'ref' ||
         name === 'class' ||
         name === 'className' ||
-        name === 'forwardedRef'
+        name === 'forwardedRef' ||
+        newProps[name] === undefined
       ) {
         return;
       }


### PR DESCRIPTION
## Change

If a property is set to undefined, instead of missing, this can lead to strange behavior in stencil components. For example default values will be overwritten with undefined. This change will filter 'undefined' values from the properties.

## Feedback

Are you open to merging this change?