### PR TITLE
fix(react): cleanup events if they are no longer passed as props

### DIFF
--- a/packages/example-project/component-library-react/__tests__/my-component.spec.tsx
+++ b/packages/example-project/component-library-react/__tests__/my-component.spec.tsx
@@ -64,6 +64,25 @@ describe('createComponent - events', () => {
     const attachedEvents = (webcomponent as any).__events;
     expect(Object.keys(attachedEvents)).toContain('myFocus');
   });
+
+  test('should clean up unused events', async () => {
+    const FakeFocus = jest.fn();
+
+    const { webcomponent, rerender } = includeWebComponent<HTMLMyInputElement>(
+      renderWithStrictMode(<MyInput onMyFocus={FakeFocus} />),
+    );
+
+    const attachedEvents = (webcomponent as any).__events;
+    expect(Object.keys(attachedEvents)).toContain('myFocus');
+
+    rerender(
+      <React.StrictMode>
+        <MyInput />
+      </React.StrictMode>,
+    );
+
+    expect(Object.keys(attachedEvents)).not.toContain('myFocus');
+  });
 });
 
 function includeWebComponent<T extends HTMLStencilElement>(results: RenderResult) {

--- a/packages/example-project/component-library-svelte/package.json
+++ b/packages/example-project/component-library-svelte/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "component-library": "file:../component-library"
+    "component-library": "0.0.4"
   },
   "devDependencies": {
     "@testing-library/svelte": "^3.0.0",

--- a/packages/example-project/component-library/package.json
+++ b/packages/example-project/component-library/package.json
@@ -31,7 +31,7 @@
     "@stencil/core": "^1.17.3",
     "@stencil/react-output-target": "^0.0.9",
     "@stencil/vue-output-target": "^0.0.3",
-    "@stencil/svelte-output-target": "file:../../svelte-output-target",
+    "@stencil/svelte-output-target": "^0.0.3",
     "@types/puppeteer": "2.0.1",
     "jest-cli": "26.0.1",
     "puppeteer": "2.1.1"


### PR DESCRIPTION
Say i have some (react) code like:

```tsx
someCondition 
  ? <MyComponent onSomeEvent={handleSomeEvent} />
  : <MyComponent />
```

Then the event handler doesn’t get removed when `someCondition` is false. 

The current code for syncing props, only considers new props when adding/removing event handlers, and doesn’t remove handlers that existed in previous props but _not_ in new props.

This PR modifies the `attachProps` util to call `removeEventListener` on any listener which is not part of the latest props. 

I had a little trouble writing a good test (read: not testing implementation details), since I think testing-library does not work well with web components. So I just followed the approach in other tests (inspecting `__events`) instead.

I also attempted to fix the build, as the `file://` urls for the svelte output target were causing issues.