### PR TITLE
fix(vue): only props set by user are passed to web component

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -105,7 +105,7 @@ export const defineContainer = <Props>(
     const navManager: NavManager | undefined = hasRouter ? inject(NAV_MANAGER) : undefined;
     const handleRouterLink = (ev: Event) => {
       const { routerLink } = props;
-      if (!routerLink) return;
+      if (routerLink === EMPTY_PROP) return;
 
       if (navManager !== undefined) {
         let navigationPayload: any = { event: ev };

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -8,7 +8,7 @@ const UPDATE_VALUE_EVENT = 'update:modelValue';
 const MODEL_VALUE = 'modelValue';
 const ROUTER_LINK_VALUE = 'routerLink';
 const NAV_MANAGER = 'navManager';
-const ROUTER_PROP_REFIX = 'router';
+const ROUTER_PROP_PREFIX = 'router';
 
 /**
  * Starting in Vue 3.1.0, all properties are
@@ -107,13 +107,15 @@ export const defineContainer = <Props>(
       const { routerLink } = props;
       if (!routerLink) return;
 
-      const routerProps = Object.keys(props).filter(p => p.startsWith(ROUTER_PROP_REFIX));
-
       if (navManager !== undefined) {
         let navigationPayload: any = { event: ev };
-        routerProps.forEach(prop => {
-          navigationPayload[prop] = props[prop];
-        });
+        for (const key in props) {
+          const value = props[key];
+          if (props.hasOwnProperty(key) && key.startsWith(ROUTER_PROP_PREFIX) && value !== EMPTY_PROP) {
+            navigationPayload[key] = value;
+          }
+        }
+
         navManager.navigate(navigationPayload);
       } else {
         console.warn('Tried to navigate, but no router was found. Make sure you have mounted Vue Router.');

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -160,9 +160,22 @@ export const defineContainer = <Props>(
       }
 
       if (modelProp) {
-        propsToAdd = {
-          ...propsToAdd,
-          [modelProp]: props[MODEL_VALUE] !== EMPTY_PROP ? props.modelValue : modelPropValue
+        /**
+         * If form value property was set using v-model
+         * then we should use that value.
+         * Otherwise, check to see if form value property
+         * was set as a static value (i.e. no v-model).
+         */
+        if (props[MODEL_VALUE] !== EMPTY_PROP) {
+          propsToAdd = {
+            ...propsToAdd,
+            [modelProp]: props.modelValue
+          }
+        } else if (modelPropValue !== EMPTY_PROP) {
+          propsToAdd = {
+            ...propsToAdd,
+            [modelProp]: modelPropValue
+          }
         }
       }
 

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -169,7 +169,7 @@ export const defineContainer = <Props>(
         if (props[MODEL_VALUE] !== EMPTY_PROP) {
           propsToAdd = {
             ...propsToAdd,
-            [modelProp]: props.modelValue
+            [modelProp]: props[MODEL_VALUE]
           }
         } else if (modelPropValue !== EMPTY_PROP) {
           propsToAdd = {

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -151,8 +151,9 @@ export const defineContainer = <Props>(
        * where as this only requires 1.
        */
       for (const key in props) {
-        if (props.hasOwnProperty(key)) {
-          propsToAdd[key] = props[key];
+        const value = props[key];
+        if (props.hasOwnProperty(key) && value !== EMPTY_PROP) {
+          propsToAdd[key] = value;
         }
       }
 

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -71,8 +71,8 @@ export const defineContainer = <Props>(
     customElements.define(name, customElement);
   }
 
-  const Container = defineComponent<Props & InputProps>((props, { attrs, slots, emit }) => {
-    let modelPropValue = (props as any)[modelProp];
+  const Container = defineComponent<Props & InputProps>((props: any, { attrs, slots, emit }) => {
+    let modelPropValue = props[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
     const onVnodeBeforeMount = (vnode: VNode) => {
@@ -104,7 +104,7 @@ export const defineContainer = <Props>(
     const hasRouter = currentInstance?.appContext?.provides[NAV_MANAGER];
     const navManager: NavManager | undefined = hasRouter ? inject(NAV_MANAGER) : undefined;
     const handleRouterLink = (ev: Event) => {
-      const { routerLink } = props as any;
+      const { routerLink } = props;
       if (!routerLink) return;
 
       const routerProps = Object.keys(props).filter(p => p.startsWith(ROUTER_PROP_REFIX));
@@ -112,7 +112,7 @@ export const defineContainer = <Props>(
       if (navManager !== undefined) {
         let navigationPayload: any = { event: ev };
         routerProps.forEach(prop => {
-          navigationPayload[prop] = (props as any)[prop];
+          navigationPayload[prop] = props[prop];
         });
         navManager.navigate(navigationPayload);
       } else {
@@ -121,13 +121,13 @@ export const defineContainer = <Props>(
     }
 
     return () => {
-      modelPropValue = (props as any)[modelProp];
+      modelPropValue = props[modelProp];
 
       getComponentClasses(attrs.class).forEach(value => {
         classes.add(value);
       });
 
-      const oldClick = (props as any).onClick;
+      const oldClick = props.onClick;
       const handleClick = (ev: Event) => {
         if (oldClick !== undefined) {
           oldClick(ev);
@@ -137,7 +137,7 @@ export const defineContainer = <Props>(
         }
       }
 
-      let propsToAdd = {
+      let propsToAdd: any = {
         ref: containerRef,
         class: getElementClasses(containerRef, classes),
         onClick: handleClick,


### PR DESCRIPTION
See https://github.com/ionic-team/ionic-framework/issues/23539 for more context. In Vue 3.1 there was a breaking change where all properties are now being included in the `props` object even if certain props were not set by the user. These unused props have a value of `undefined`.

With Custom Elements, this causes issues as certain internal values such as event emitters are set on the web component instance resulting in them getting wiped out due to this Vue 3.1 behavior.

This PR fixes the issue by setting the default value of all props to be a `Symbol` so that we can check if the value of a property was not set while respecting properties that can accept `undefined` as a value.