### PR TITLE
Add legacy support for Angular ValueAccessors

### DIFF
--- a/packages/angular-output-target/resources/control-value-accessors-legacy/boolean-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors-legacy/boolean-value-accessor.ts
@@ -1,18 +1,30 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-@Directive()
-export class ValueAccessor implements ControlValueAccessor {
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: '<VALUE_ACCESSOR_SELECTORS>',
+  host: {
+    '(<VALUE_ACCESSOR_EVENT>)': 'handleChangeEvent($event.target.<VALUE_ACCESSOR_TARGETATTR>)'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: BooleanValueAccessor,
+      multi: true
+    }
+  ]
+})
+export class BooleanValueAccessor implements ControlValueAccessor {
 
-  protected lastValue: any;
-
+  private lastValue: any;
   private onChange: (value: any) => void = () => {/**/};
   private onTouched: () => void = () => {/**/};
 
   constructor(protected el: ElementRef) {}
 
   writeValue(value: any) {
-    this.el.nativeElement.value = this.lastValue = value == null ? '' : value;
+    this.el.nativeElement.checked = this.lastValue = value == null ? false : value;
   }
 
   handleChangeEvent(value: any) {

--- a/packages/angular-output-target/resources/control-value-accessors-legacy/number-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors-legacy/number-value-accessor.ts
@@ -1,11 +1,23 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-@Directive()
-export class ValueAccessor implements ControlValueAccessor {
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: '<VALUE_ACCESSOR_SELECTORS>',
+  host: {
+    '(<VALUE_ACCESSOR_EVENT>)': 'handleChangeEvent($event.target.<VALUE_ACCESSOR_TARGETATTR>)'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: NumericValueAccessor,
+      multi: true
+    }
+  ]
+})
+export class NumericValueAccessor implements ControlValueAccessor {
 
-  protected lastValue: any;
-
+  private lastValue: any;
   private onChange: (value: any) => void = () => {/**/};
   private onTouched: () => void = () => {/**/};
 
@@ -27,8 +39,10 @@ export class ValueAccessor implements ControlValueAccessor {
     this.onTouched();
   }
 
-  registerOnChange(fn: (value: any) => void) {
-    this.onChange = fn;
+  registerOnChange(fn: (_: number | null) => void) {
+    this.onChange = value => {
+      fn(value === '' ? null : parseFloat(value));
+    };
   }
 
   registerOnTouched(fn: () => void) {

--- a/packages/angular-output-target/resources/control-value-accessors-legacy/radio-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors-legacy/radio-value-accessor.ts
@@ -1,11 +1,23 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-@Directive()
-export class ValueAccessor implements ControlValueAccessor {
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: '<VALUE_ACCESSOR_SELECTORS>',
+  host: {
+    '(<VALUE_ACCESSOR_EVENT>)': 'handleChangeEvent($event.target.<VALUE_ACCESSOR_TARGETATTR>)'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: RadioValueAccessor,
+      multi: true
+    }
+  ]
+})
+export class RadioValueAccessor implements ControlValueAccessor {
 
-  protected lastValue: any;
-
+  private lastValue: any;
   private onChange: (value: any) => void = () => {/**/};
   private onTouched: () => void = () => {/**/};
 

--- a/packages/angular-output-target/resources/control-value-accessors-legacy/select-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors-legacy/select-value-accessor.ts
@@ -1,11 +1,23 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-@Directive()
-export class ValueAccessor implements ControlValueAccessor {
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: '<VALUE_ACCESSOR_SELECTORS>',
+  host: {
+    '(<VALUE_ACCESSOR_EVENT>)': 'handleChangeEvent($event.target.<VALUE_ACCESSOR_TARGETATTR>)'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: SelectValueAccessor,
+      multi: true
+    }
+  ]
+})
+export class SelectValueAccessor implements ControlValueAccessor {
 
-  protected lastValue: any;
-
+  private lastValue: any;
   private onChange: (value: any) => void = () => {/**/};
   private onTouched: () => void = () => {/**/};
 

--- a/packages/angular-output-target/resources/control-value-accessors-legacy/text-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors-legacy/text-value-accessor.ts
@@ -1,11 +1,23 @@
 import { Directive, ElementRef, HostListener } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-@Directive()
-export class ValueAccessor implements ControlValueAccessor {
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: '<VALUE_ACCESSOR_SELECTORS>',
+  host: {
+    '(<VALUE_ACCESSOR_EVENT>)': 'handleChangeEvent($event.target.<VALUE_ACCESSOR_TARGETATTR>)'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: TextValueAccessor,
+      multi: true
+    }
+  ]
+})
+export class TextValueAccessor implements ControlValueAccessor {
 
-  protected lastValue: any;
-
+  private lastValue: any;
   private onChange: (value: any) => void = () => {/**/};
   private onTouched: () => void = () => {/**/};
 

--- a/packages/angular-output-target/src/generate-value-accessors.ts
+++ b/packages/angular-output-target/src/generate-value-accessors.ts
@@ -25,6 +25,10 @@ export default async function generateValueAccessors(
     return;
   }
 
+  const sourcePath =
+    outputTarget.legacyValueAccessors !== true
+      ? '../resources/control-value-accessors/'
+      : '../resources/control-value-accessors-legacy/';
   const targetDir = path.dirname(outputTarget.directivesProxyFile);
 
   const normalizedValueAccessors: NormalizedValueAccessors = outputTarget.valueAccessorConfigs.reduce(
@@ -56,11 +60,7 @@ export default async function generateValueAccessors(
       const valueAccessorType = type as ValueAccessorTypes; // Object.keys converts to string
       const targetFileName = `${type}-value-accessor.ts`;
       const targetFilePath = path.join(targetDir, targetFileName);
-      const srcFilePath = path.join(
-        __dirname,
-        '../resources/control-value-accessors/',
-        targetFileName,
-      );
+      const srcFilePath = path.join(__dirname, sourcePath, targetFileName);
       const srcFileContents = await compilerCtx.fs.readFile(srcFilePath);
 
       const finalText = createValueAccessor(
@@ -71,7 +71,9 @@ export default async function generateValueAccessors(
     }),
   );
 
-  await copyResources(config, ['value-accessor.ts'], targetDir);
+  if (outputTarget.legacyValueAccessors !== true) {
+    await copyResources(config, ['value-accessor.ts'], targetDir);
+  }
 }
 
 export function createValueAccessor(srcFileContents: string, valueAccessor: ValueAccessor) {

--- a/packages/angular-output-target/src/types.ts
+++ b/packages/angular-output-target/src/types.ts
@@ -4,6 +4,7 @@ export interface OutputTargetAngular {
   directivesArrayFile?: string;
   directivesUtilsFile?: string;
   valueAccessorConfigs?: ValueAccessorConfig[];
+  legacyValueAccessors?: boolean;
   excludeComponents?: string[];
 }
 


### PR DESCRIPTION
* add legacyValueAccessors flag to OutputTargetAngular type (false by default to keep the behaviour consistent with the current build process)
* add non extended value accessors for angular < 9 support
* update value accessors generator script to handle legacy support

With the addition of the empty @Directive decorator, there is a breaking change with projects using angular < 9. To fix the issue, the users had to manually remove the decorator or move the extended code from the abstract ValueAccessor class to the other value accessors.
This PR intends to fix this by adding a legacy flag to the compiler that will do just this.
see: https://angular.io/guide/migration-undecorated-classes#im-a-library-author-should-i-add-the-directive-decorator-to-base-classes