### PR TITLE
feat(angular): use Angular's EventEmitter with correct type in generated proxy components

### DIFF
--- a/packages/angular-output-target/__tests__/output-angular.spec.ts
+++ b/packages/angular-output-target/__tests__/output-angular.spec.ts
@@ -19,7 +19,7 @@ describe('generateProxies', () => {
     expect(finalText).toEqual(
       `/* tslint:disable */
 /* auto-generated angular directive proxies */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, NgZone } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 
 import { Components } from 'component-library';
@@ -37,7 +37,7 @@ import { Components } from 'component-library';
     expect(finalText).toEqual(
       `/* tslint:disable */
 /* auto-generated angular directive proxies */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, NgZone } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 
 import { Components } from '../../angular-output-target/dist/types/components';

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -40,28 +40,28 @@ export const createComponentDefinition = (
     ),
   );
   const importPath = normalizePath(path.join(typePath.dir, typePath.name));
-  const outputsInterface: string[] = ['']; // Empty first line
+  const outputsInterface: Set<string> = new Set();
 
   const outputReferenceRemap: { [p: string]: string } = {};
   outputs.forEach((output) => {
     Object.entries(output.complexType.references).forEach(([reference, refObject]) => {
       // Add import line for each local/import reference, and add new mapping name
       const remappedReference = `I${cmpMeta.componentClassName}${reference}`;
+      outputReferenceRemap[reference] = remappedReference;
       if (refObject.location === 'local') {
-        outputReferenceRemap[reference] = remappedReference;
-        outputsInterface.push(`import { ${reference} as ${remappedReference} } from '${importPath}';`);
+        outputsInterface.add(`import { ${reference} as ${remappedReference} } from '${importPath}';`);
       } else if (refObject.location === 'import') {
-        outputReferenceRemap[reference] = remappedReference;
         const interfacePath = normalizePath(
           isRelativePath(refObject.path!) ? path.join(typePath.dir, refObject.path!) : refObject.path!,
         );
-        outputsInterface.push(`import { ${reference} as ${remappedReference} } from '${interfacePath}';`);
+        outputsInterface.add(`import { ${reference} as ${remappedReference} } from '${interfacePath}';`);
       }
     });
   });
 
   const lines = [
-    `${outputsInterface.join('\n')}
+    '', // Empty first line
+    `${[...outputsInterface].join('\n')}
 export declare interface ${tagNameAsPascal} extends Components.${tagNameAsPascal} {}
 ${getProxyCmp(inputs, methods)}
 @Component({

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -46,11 +46,14 @@ export const createComponentDefinition = (
   outputs.forEach((output) => {
     Object.entries(output.complexType.references).forEach(([reference, refObject]) => {
       // Add import line for each local/import reference, and add new mapping name
+      // outputReferenceRemap should be updated only if the import interface is set in outputsInterface
+      // This will prevent global types to be remapped
       const remappedReference = `I${cmpMeta.componentClassName}${reference}`;
-      outputReferenceRemap[reference] = remappedReference;
       if (refObject.location === 'local') {
+        outputReferenceRemap[reference] = remappedReference;
         outputsInterface.add(`import { ${reference} as ${remappedReference} } from '${importPath}';`);
       } else if (refObject.location === 'import') {
+        outputReferenceRemap[reference] = remappedReference;
         const interfacePath = normalizePath(
           isRelativePath(refObject.path!) ? path.join(typePath.dir, refObject.path!) : refObject.path!,
         );

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -78,7 +78,12 @@ export class ${tagNameAsPascal} {`,
     lines.push(
       `  /** ${output.docs.text} ${output.docs.tags.map((tag) => `@${tag.name} ${tag.text}`)}*/`,
     );
-    // Regexp to replace output references with their remapped name
+    /**
+     * The original attribute contains the original type defined by the devs.
+     * This regexp normalizes the reference, by removing linebreaks,
+     * replacing consecutive spaces with a single space, and adding a single space after commas.
+     **/
+
     const outputTypeRemapped = Object.entries(outputReferenceRemap).reduce((type, [src, dst]) => {
       return type
         .replace(new RegExp(`^${src}$`, 'g'), `${dst}`)

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -80,7 +80,7 @@ export class ${tagNameAsPascal} {`,
       return type
         .replace(new RegExp(`^${src}$`, 'g'), `${dst}`)
         .replace(
-          new RegExp(`([\\s<]|:\\s?)\\s*${src}\\s*((?<=[\\s<]\\s*${src}\\s*)[,<>]|(?<=:\\s*${src}\\s*)[,\\s}])`, 'g'),
+          new RegExp(`([^\\w])${src}([^\\w])`, 'g'),
           (v, p1, p2) => [p1, dst, p2].join(''),
         );
     }, output.complexType.original

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -79,9 +79,15 @@ export class ${tagNameAsPascal} {`,
     const outputTypeRemapped = Object.entries(outputReferenceRemap).reduce((type, [src, dst]) => {
       return type
         .replace(new RegExp(`^${src}$`, 'g'), `${dst}`)
-        .replace(new RegExp(`(:\\s)${src}([,\\s]{1})`, 'g'), `$1${dst}$2`);
-    }, output.complexType.original);
-    lines.push(`  ${output.name}!: EventEmitter<CustomEvent<${outputTypeRemapped}>>;`);
+        .replace(
+          new RegExp(`([\\s<]|:\\s?)\\s*${src}\\s*((?<=[\\s<]\\s*${src}\\s*)[,<>]|(?<=:\\s*${src}\\s*)[,\\s}])`, 'g'),
+          (v, p1, p2) => [p1, dst, p2].join(''),
+        );
+    }, output.complexType.original
+      .replace(/\n/g, ' ')
+      .replace(/\s{2,}/g, ' ')
+      .replace(/,\s*/g, ', '));
+    lines.push(`  ${output.name}!: EventEmitter<CustomEvent<${outputTypeRemapped.trim()}>>;`);
   });
 
   lines.push('  protected el: HTMLElement;');

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -72,7 +72,7 @@ export function generateProxies(
 
   const imports = `/* tslint:disable */
 /* auto-generated angular directive proxies */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, NgZone } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';\n`;
 
   const typeImports = !outputTarget.componentCorePackage

--- a/packages/angular-output-target/src/utils.ts
+++ b/packages/angular-output-target/src/utils.ts
@@ -64,6 +64,10 @@ export function relativeImport(pathFrom: string, pathTo: string, ext?: string) {
   return normalizePath(`${relativePath}/${path.basename(pathTo, ext)}`);
 }
 
+export function isRelativePath(path: string) {
+  return path && path.startsWith('.');
+}
+
 export async function readPackageJson(rootDir: string) {
   const pkgJsonPath = path.join(rootDir, 'package.json');
 


### PR DESCRIPTION
* use outputs' complexType definition to detect the output type
* replace className[attribute] value for outputs with Angular's EventEmitter: EvenEmitter<CustomEvent<T>>

The objective is to set the expected output type on each generated proxy component, as the method generateProxyOutputs replaces the original signature by an EventEmitter.

This should fix https://github.com/ionic-team/stencil-ds-output-targets/issues/155