### PR TITLE
Remove path and os dependencies, lean on Stencil's Systems abstractio…

### DIFF
--- a/packages/angular-output-target/__tests__/generate-value-accessors.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-value-accessors.spec.ts
@@ -2,8 +2,11 @@ import { createValueAccessor, ValueAccessor } from '../src/generate-value-access
 import { EOL } from 'os';
 import path from 'path';
 import fs from 'fs';
+import { createTestingSystem } from './helpers';
 
 describe('createValueAccessor', () => {
+  const config = createTestingSystem();
+  
   it('should create a valid {type}-value-accessor.ts file when multiple value accessors of the same type are in the config', () => {
     const valueAccessor: ValueAccessor = {
       elementSelectors: ['my-input[type=text]', 'my-input[type=email]'],
@@ -18,7 +21,7 @@ describe('createValueAccessor', () => {
       '../resources/control-value-accessors/text-value-accessor.ts',
     );
     const srcFile = fs.readFileSync(srcFilePath, { encoding: 'utf-8' });
-    const finalText = createValueAccessor(srcFile, valueAccessor);
+    const finalText = createValueAccessor(config, srcFile, valueAccessor);
     const exptectedOutput = `import { Directive, ElementRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 

--- a/packages/angular-output-target/__tests__/helpers.ts
+++ b/packages/angular-output-target/__tests__/helpers.ts
@@ -1,0 +1,16 @@
+import { Config } from '@stencil/core/internal';
+import { relative, normalize, dirname, basename, isAbsolute, join } from 'path';
+
+export const createTestingSystem = (): Config => {
+  return {
+    rootDir: '/dev/',
+    sys: {
+      resolvePath: normalize,
+      relative: relative,
+      dirname: dirname,
+      basename: basename,
+      isAbsolutePath: isAbsolute,
+      joinPaths: join,
+    },
+  } as Config;
+};

--- a/packages/angular-output-target/__tests__/output-angular.spec.ts
+++ b/packages/angular-output-target/__tests__/output-angular.spec.ts
@@ -1,6 +1,7 @@
-import { ComponentCompilerMeta } from '@stencil/core/internal';
+import type { ComponentCompilerMeta, Config, CopyTask } from '@stencil/core/internal';
+import type { PackageJSON, OutputTargetAngular } from '../src/types';
 import { generateProxies } from '../src/output-angular';
-import { PackageJSON, OutputTargetAngular } from '../src/types';
+import { createTestingSystem } from './helpers';
 
 describe('generateProxies', () => {
   const components: ComponentCompilerMeta[] = [];
@@ -8,6 +9,7 @@ describe('generateProxies', () => {
     types: 'dist/types/index.d.ts',
   };
   const rootDir: string = '';
+  const config = createTestingSystem();
 
   it('should use types from the component-library when it is provided to the config', () => {
     const outputTarget: OutputTargetAngular = {
@@ -15,7 +17,14 @@ describe('generateProxies', () => {
       directivesProxyFile: '../component-library-angular/src/proxies.ts',
     };
 
-    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    const finalText = generateProxies(
+      components,
+      pkgData,
+      outputTarget,
+      rootDir,
+      config,
+      {} as any,
+    );
     expect(finalText).toEqual(
       `/* tslint:disable */
 /* auto-generated angular directive proxies */
@@ -33,14 +42,21 @@ import { Components } from 'component-library';
       directivesProxyFile: '../component-library-angular/src/proxies.ts',
     };
 
-    const finalText = generateProxies(components, pkgData, outputTarget, rootDir);
+    const finalText = generateProxies(
+      components,
+      pkgData,
+      outputTarget,
+      rootDir,
+      config,
+      {} as any,
+    );
     expect(finalText).toEqual(
       `/* tslint:disable */
 /* auto-generated angular directive proxies */
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 
-import { Components } from '../../angular-output-target/dist/types/components';
+import { Components } from '../component-library-angular/dist/types/components';
 
 `,
     );

--- a/packages/angular-output-target/__tests__/plugin.spec.ts
+++ b/packages/angular-output-target/__tests__/plugin.spec.ts
@@ -1,11 +1,10 @@
 import { Config } from '@stencil/core/internal';
 import { OutputTargetAngular } from '../src/types';
 import { normalizeOutputTarget } from '../src/plugin';
+import { createTestingSystem } from './helpers';
 
 describe('normalizeOutputTarget', () => {
-  const config: Config = {
-    rootDir: '/dev/',
-  };
+  const config = createTestingSystem();
 
   it('should return fail if proxiesFile is not set', () => {
     expect(() => {

--- a/packages/angular-output-target/src/generate-angular-directives-file.ts
+++ b/packages/angular-output-target/src/generate-angular-directives-file.ts
@@ -1,8 +1,9 @@
 import type { OutputTargetAngular } from './types';
 import { dashToPascalCase, relativeImport } from './utils';
-import type { CompilerCtx, ComponentCompilerMeta } from '@stencil/core/internal';
+import type { CompilerCtx, ComponentCompilerMeta, Config } from '@stencil/core/internal';
 
 export function generateAngularDirectivesFile(
+  config: Config,
   compilerCtx: CompilerCtx,
   components: ComponentCompilerMeta[],
   outputTarget: OutputTargetAngular,
@@ -13,6 +14,7 @@ export function generateAngularDirectivesFile(
   }
 
   const proxyPath = relativeImport(
+    config,
     outputTarget.directivesArrayFile,
     outputTarget.directivesProxyFile,
     '.ts',

--- a/packages/angular-output-target/src/generate-value-accessors.ts
+++ b/packages/angular-output-target/src/generate-value-accessors.ts
@@ -1,5 +1,3 @@
-import { EOL } from 'os';
-import path from 'path';
 import type { OutputTargetAngular, ValueAccessorTypes } from './types';
 import type { CompilerCtx, ComponentCompilerMeta, Config } from '@stencil/core/internal';
 
@@ -25,56 +23,71 @@ export default async function generateValueAccessors(
     return;
   }
 
-  const targetDir = path.dirname(outputTarget.directivesProxyFile);
+  if (!config.sys || !config.sys.dirname || !config.sys.normalizePath || !config.sys.joinPaths) {
+    throw new Error('stencil is not properly initialized at this step. Notify the developer');
+  }
 
-  const normalizedValueAccessors: NormalizedValueAccessors = outputTarget.valueAccessorConfigs.reduce(
-    (allAccessors, va) => {
-      const elementSelectors = Array.isArray(va.elementSelectors)
-        ? va.elementSelectors
-        : [va.elementSelectors];
-      const type = va.type;
-      let allElementSelectors: string[] = [];
-      let allEventTargets: [string, string][] = [];
+  if (!!config.sys) {
+    const targetDir = config.sys.dirname(outputTarget.directivesProxyFile);
 
-      if (allAccessors.hasOwnProperty(type)) {
-        allElementSelectors = allAccessors[type].elementSelectors;
-        allEventTargets = allAccessors[type].eventTargets;
-      }
-      return {
-        ...allAccessors,
-        [type]: {
-          elementSelectors: allElementSelectors.concat(elementSelectors),
-          eventTargets: allEventTargets.concat([[va.event, va.targetAttr]]),
-        },
-      };
-    },
-    {} as NormalizedValueAccessors,
-  );
+    const normalizedValueAccessors: NormalizedValueAccessors =
+      outputTarget.valueAccessorConfigs.reduce((allAccessors, va) => {
+        const elementSelectors = Array.isArray(va.elementSelectors)
+          ? va.elementSelectors
+          : [va.elementSelectors];
+        const type = va.type;
+        let allElementSelectors: string[] = [];
+        let allEventTargets: [string, string][] = [];
 
-  await Promise.all(
-    Object.keys(normalizedValueAccessors).map(async (type) => {
-      const valueAccessorType = type as ValueAccessorTypes; // Object.keys converts to string
-      const targetFileName = `${type}-value-accessor.ts`;
-      const targetFilePath = path.join(targetDir, targetFileName);
-      const srcFilePath = path.join(
-        __dirname,
-        '../resources/control-value-accessors/',
-        targetFileName,
+        if (allAccessors.hasOwnProperty(type)) {
+          allElementSelectors = allAccessors[type].elementSelectors;
+          allEventTargets = allAccessors[type].eventTargets;
+        }
+        return {
+          ...allAccessors,
+          [type]: {
+            elementSelectors: allElementSelectors.concat(elementSelectors),
+            eventTargets: allEventTargets.concat([[va.event, va.targetAttr]]),
+          },
+        };
+      }, {} as NormalizedValueAccessors);
+
+    if (typeof config.sys !== 'undefined') {
+      await Promise.all(
+        Object.keys(normalizedValueAccessors).map(async (type) => {
+          const valueAccessorType = type as ValueAccessorTypes; // Object.keys converts to string
+          const targetFileName = `${type}-value-accessor.ts`;
+          const targetFilePath =
+            config.sys?.normalizePath(config.sys?.joinPaths(targetDir, targetFileName) || '') || '';
+          const srcFilePath =
+            config.sys?.normalizePath(
+              config.sys?.joinPaths(
+                __dirname,
+                '../resources/control-value-accessors/',
+                targetFileName,
+              ) || '',
+            ) || '';
+          const srcFileContents = await compilerCtx.fs.readFile(srcFilePath);
+
+          const finalText = createValueAccessor(
+            config,
+            srcFileContents,
+            normalizedValueAccessors[valueAccessorType],
+          );
+          await compilerCtx.fs.writeFile(targetFilePath, finalText);
+        }),
       );
-      const srcFileContents = await compilerCtx.fs.readFile(srcFilePath);
 
-      const finalText = createValueAccessor(
-        srcFileContents,
-        normalizedValueAccessors[valueAccessorType],
-      );
-      await compilerCtx.fs.writeFile(targetFilePath, finalText);
-    }),
-  );
-
-  await copyResources(config, ['value-accessor.ts'], targetDir);
+      await copyResources(config, ['value-accessor.ts'], targetDir);
+    }
+  }
 }
 
-export function createValueAccessor(srcFileContents: string, valueAccessor: ValueAccessor) {
+export function createValueAccessor(
+  config: Config,
+  srcFileContents: string,
+  valueAccessor: ValueAccessor,
+) {
   const hostContents = valueAccessor.eventTargets.map((listItem) =>
     VALUE_ACCESSOR_EVENTTARGETS.replace(VALUE_ACCESSOR_EVENT, listItem[0]).replace(
       VALUE_ACCESSOR_TARGETATTR,
@@ -84,22 +97,26 @@ export function createValueAccessor(srcFileContents: string, valueAccessor: Valu
 
   return srcFileContents
     .replace(VALUE_ACCESSOR_SELECTORS, valueAccessor.elementSelectors.join(', '))
-    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join(`,${EOL}`));
+    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join(`,${config.sys?.EOL || '\n'}`));
 }
 
 function copyResources(config: Config, resourcesFilesToCopy: string[], directory: string) {
-  if (!config.sys || !config.sys.copy) {
+  if (!config.sys || !config.sys.copy || !config.sys.normalizePath) {
     throw new Error('stencil is not properly intialized at this step. Notify the developer');
   }
   const copyTasks = resourcesFilesToCopy.map((rf) => {
     return {
-      src: path.join(__dirname, '../resources/control-value-accessors/', rf),
-      dest: path.join(directory, rf),
+      src:
+        config.sys?.normalizePath(
+          [__dirname, '../resources/control-value-accessors/', rf].join('/'),
+        ) || '',
+      dest: config.sys?.normalizePath([directory, rf].join('/')) || '',
       keepDirStructure: false,
       warn: false,
     };
   });
-  return config.sys.copy(copyTasks, path.join(directory));
+
+  return config.sys.copy(copyTasks, config.sys?.normalizePath(directory));
 }
 
 const VALUE_ACCESSOR_SELECTORS = `<VALUE_ACCESSOR_SELECTORS>`;

--- a/packages/angular-output-target/src/plugin.ts
+++ b/packages/angular-output-target/src/plugin.ts
@@ -2,7 +2,6 @@ import type { Config, OutputTargetCustom } from '@stencil/core/internal';
 import { normalizePath } from './utils';
 import { angularDirectiveProxyOutput } from './output-angular';
 import type { OutputTargetAngular } from './types';
-import path from 'path';
 
 export const angularOutputTarget = (outputTarget: OutputTargetAngular): OutputTargetCustom => ({
   type: 'custom',
@@ -33,22 +32,33 @@ export function normalizeOutputTarget(config: Config, outputTarget: any) {
     throw new Error('directivesProxyFile is required');
   }
 
-  if (outputTarget.directivesProxyFile && !path.isAbsolute(outputTarget.directivesProxyFile)) {
-    results.directivesProxyFile = normalizePath(
-      path.join(config.rootDir, outputTarget.directivesProxyFile),
-    );
-  }
+  if (config.sys) {
+    if (
+      outputTarget.directivesProxyFile &&
+      !config.sys?.isAbsolutePath(outputTarget.directivesProxyFile)
+    ) {
+      const proxyPath =
+        config.sys.joinPaths(config.rootDir, outputTarget.directivesProxyFile) || '';
+      results.directivesProxyFile = normalizePath(proxyPath);
+    }
 
-  if (outputTarget.directivesArrayFile && !path.isAbsolute(outputTarget.directivesArrayFile)) {
-    results.directivesArrayFile = normalizePath(
-      path.join(config.rootDir, outputTarget.directivesArrayFile),
-    );
-  }
+    if (
+      outputTarget.directivesArrayFile &&
+      !config.sys?.isAbsolutePath(outputTarget.directivesArrayFile)
+    ) {
+      const arrayPath =
+        config.sys.joinPaths(config.rootDir, outputTarget.directivesArrayFile) || '';
+      results.directivesArrayFile = normalizePath(arrayPath);
+    }
 
-  if (outputTarget.directivesUtilsFile && !path.isAbsolute(outputTarget.directivesUtilsFile)) {
-    results.directivesUtilsFile = normalizePath(
-      path.join(config.rootDir, outputTarget.directivesUtilsFile),
-    );
+    if (
+      outputTarget.directivesUtilsFile &&
+      !config.sys?.isAbsolutePath(outputTarget.directivesUtilsFile)
+    ) {
+      const utilsPath =
+        config.sys.joinPaths(config.rootDir, outputTarget.directivesUtilsFile) || '';
+      results.directivesUtilsFile = normalizePath(utilsPath);
+    }
   }
 
   return results;


### PR DESCRIPTION
Remove path and os dependencies, lean on Stencil's Systems abstraction to interact with the system.

Depends on https://github.com/ionic-team/stencil/pull/3140

This allows the Angular binding to work with newer versions of Stencil without the need for external dependencies or polyfills. 