### PR TITLE
fix(react): use createElement named import for better compatibility with Vite

### DIFF
--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createElement } from 'react';
 
 import {
   attachProps,
@@ -80,7 +80,7 @@ export const createReactComponent = <
         style,
       };
 
-      return React.createElement(tagName, newProps, children);
+      return createElement(tagName, newProps, children);
     }
 
     static get displayName() {

--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -80,6 +80,13 @@ export const createReactComponent = <
         style,
       };
 
+      /**
+       * We use createElement here instead of
+       * React.createElement to work around a
+       * bug in Vite (https://github.com/vitejs/vite/issues/6104).
+       * React.createElement causes all elements to be rendered
+       * as <tagname> instead of the actual Web Component.
+       */
       return createElement(tagName, newProps, children);
     }
 


### PR DESCRIPTION
Using `React.createElement` causes Vite to render all components in a Stencil app as `<tagname>` rather than the actual Web Component. See original Ionic issue: https://github.com/ionic-team/ionic-framework/issues/24229

I have identified this to be a Vite bug. See Vite issue: https://github.com/vitejs/vite/issues/6104

According to https://github.com/vitejs/vite/issues/6104#issuecomment-999050698, using the `createElement` named import instead of `React.createElement` fixes the issue. I have verified that this does indeed fix the issue.

I propose we merge this PR in order to get developers unstuck.