### PR TITLE
chore(react): add function-level jsdoc

### DIFF
--- a/packages/react-output-target/__tests__/generate-react-components.spec.ts
+++ b/packages/react-output-target/__tests__/generate-react-components.spec.ts
@@ -32,7 +32,7 @@ describe('generateProxies', () => {
   const rootDir: string = '';
   const config: Config = { outputTargets: [] };
 
-  it('should include both polyfills and definCustomElements when both are true in the outputTarget', () => {
+  it('should include both polyfills and defineCustomElements when both are true in the outputTarget', () => {
     const outputTarget: OutputTargetReact = {
       componentCorePackage: 'component-library',
       proxiesFile: '../component-library-react/src/proxies.ts',

--- a/packages/react-output-target/src/output-react.ts
+++ b/packages/react-output-target/src/output-react.ts
@@ -5,15 +5,23 @@ import type {
   CompilerCtx,
   ComponentCompilerMeta,
   Config,
+  CopyResults,
   OutputTargetDist,
 } from '@stencil/core/internal';
 
+/**
+ * Generate and write the Stencil-React bindings to disc
+ * @param config the Stencil configuration associated with the project
+ * @param compilerCtx the compiler context of the current Stencil build
+ * @param outputTarget the output target configuration for generating the React wrapper
+ * @param components the components to generate the bindings for
+ */
 export async function reactProxyOutput(
   config: Config,
   compilerCtx: CompilerCtx,
   outputTarget: OutputTargetReact,
-  components: ComponentCompilerMeta[],
-) {
+  components: ReadonlyArray<ComponentCompilerMeta>,
+): Promise<void> {
   const filteredComponents = getFilteredComponents(outputTarget.excludeComponents, components);
   const rootDir = config.rootDir as string;
   const pkgData = await readPackageJson(rootDir);
@@ -23,19 +31,34 @@ export async function reactProxyOutput(
   await copyResources(config, outputTarget);
 }
 
-function getFilteredComponents(excludeComponents: string[] = [], cmps: ComponentCompilerMeta[]) {
+/**
+ * Removes all components from the provided `cmps` list that exist in the provided `excludedComponents` list
+ * @param excludeComponents the list of components that should be removed from the provided `cmps` list
+ * @param cmps a list of components
+ * @returns the filtered list of components
+ */
+function getFilteredComponents(excludeComponents: ReadonlyArray<string> = [], cmps: readonly ComponentCompilerMeta[]): ReadonlyArray<ComponentCompilerMeta> {
   return sortBy(cmps, (cmp) => cmp.tagName).filter(
     (c) => !excludeComponents.includes(c.tagName) && !c.internal,
   );
 }
 
+/**
+ * Generate the code that will be responsible for creating the Stencil-React bindings
+ * @param config the Stencil configuration associated with the project
+ * @param components the Stencil components to generate wrappers for
+ * @param pkgData `package.json` data for the Stencil project
+ * @param outputTarget the output target configuration used to generate the Stencil-React bindings
+ * @param rootDir the directory of the Stencil project
+ * @returns the generated code to create the Stencil-React bindings
+ */
 export function generateProxies(
   config: Config,
-  components: ComponentCompilerMeta[],
+  components: ReadonlyArray<ComponentCompilerMeta>,
   pkgData: PackageJSON,
   outputTarget: OutputTargetReact,
   rootDir: string,
-) {
+): string {
   const distTypesDir = path.dirname(pkgData.types);
   const dtsFilePath = path.join(rootDir, distTypesDir, GENERATED_DTS);
   const componentsTypeFile = relativeImport(outputTarget.proxiesFile, dtsFilePath, '.d.ts');
@@ -67,10 +90,9 @@ import { createReactComponent } from './react-component-lib';\n`;
   let registerCustomElements = '';
 
   /**
-   * Build an array of Custom Elements build imports and namespace them
-   * so that they do not conflict with the React wrapper names. For example,
-   * IonButton would be imported as IonButtonCmp so as to not conflict with the
-   * IonButton React Component that takes in the Web Component as a parameter.
+   * Build an array of Custom Elements build imports and namespace them so that they do not conflict with the React
+   * wrapper names. For example, IonButton would be imported as IonButtonCmp to not conflict with the IonButton React
+   * Component that takes in the Web Component as a parameter.
    */
   if (outputTarget.includeImportCustomElements && outputTarget.componentCorePackage !== undefined) {
     const cmpImports = components.map(component => {
@@ -91,7 +113,7 @@ import { createReactComponent } from './react-component-lib';\n`;
     registerCustomElements = `${REGISTER_CUSTOM_ELEMENTS}();`;
   }
 
-  const final: string[] = [
+  const final: ReadonlyArray<string> = [
     imports,
     typeImports,
     sourceImports,
@@ -103,16 +125,13 @@ import { createReactComponent } from './react-component-lib';\n`;
 }
 
 /**
- * Defines the React component that developers will import
- * to use in their applications.
- * @param cmpMeta: Meta data for a single Web Component
- * @param includeCustomElement: If `true`, the Web Component instance
- * will be passed in to createReactComponent to be registered
- * with the Custom Elements Registry.
- * @returns An array where each entry is a string version
- * of the React component definition.
+ * Defines the React component that developers will import to use in their applications.
+ * @param cmpMeta Meta data for a single Web Component
+ * @param includeCustomElement If `true`, the Web Component instance will be passed in to createReactComponent to be
+ * registered with the Custom Elements Registry.
+ * @returns An array where each entry is a string version of the React component definition.
  */
-export function createComponentDefinition(cmpMeta: ComponentCompilerMeta, includeCustomElement: boolean = false): string[] {
+export function createComponentDefinition(cmpMeta: ComponentCompilerMeta, includeCustomElement: boolean = false): ReadonlyArray<string> {
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
   let template = `export const ${tagNameAsPascal} = /*@__PURE__*/createReactComponent<${IMPORT_TYPES}.${tagNameAsPascal}, HTML${tagNameAsPascal}Element>('${cmpMeta.tagName}'`;
 
@@ -127,7 +146,14 @@ export function createComponentDefinition(cmpMeta: ComponentCompilerMeta, includ
   ];
 }
 
-async function copyResources(config: Config, outputTarget: OutputTargetReact) {
+/**
+ * Copy resources used to generate the Stencil-React bindings. The resources copied here are not specific a project's
+ * Stencil components, but rather the logic used to do the actual component generation.
+ * @param config the Stencil configuration associated with the project
+ * @param outputTarget the output target configuration for generating the Stencil-React bindings
+ * @returns The results of performing the copy
+ */
+async function copyResources(config: Config, outputTarget: OutputTargetReact): Promise<CopyResults> {
   if (!config.sys || !config.sys.copy || !config.sys.glob) {
     throw new Error('stencil is not properly initialized at this step. Notify the developer');
   }
@@ -147,7 +173,13 @@ async function copyResources(config: Config, outputTarget: OutputTargetReact) {
   );
 }
 
-export function getPathToCorePackageLoader(config: Config, outputTarget: OutputTargetReact) {
+/**
+ * Derive the path to the loader
+ * @param config the Stencil configuration for the project
+ * @param outputTarget the output target used for generating the Stencil-React bindings
+ * @returns the derived loader path
+ */
+export function getPathToCorePackageLoader(config: Config, outputTarget: OutputTargetReact): string {
   const basePkg = outputTarget.componentCorePackage || '';
   const distOutputTarget = config.outputTargets?.find((o) => o.type === 'dist') as OutputTargetDist;
 

--- a/packages/react-output-target/src/plugin.ts
+++ b/packages/react-output-target/src/plugin.ts
@@ -4,6 +4,11 @@ import type { OutputTargetReact } from './types';
 import { reactProxyOutput } from './output-react';
 import path from 'path';
 
+/**
+ * Creates an output target for binding Stencil components to be used in a React context
+ * @param outputTarget the user-defined output target defined in a Stencil configuration file
+ * @returns an output target that can be used by the Stencil compiler
+ */
 export const reactOutputTarget = (outputTarget: OutputTargetReact): OutputTargetCustom => ({
   type: 'custom',
   name: 'react-library',
@@ -19,7 +24,14 @@ export const reactOutputTarget = (outputTarget: OutputTargetReact): OutputTarget
   },
 });
 
-export function normalizeOutputTarget(config: Config, outputTarget: any) {
+/**
+ * Normalizes the structure of a provided output target and verifies a Stencil configuration
+ * associated with the wrapper is valid
+ * @param config the configuration to validate
+ * @param outputTarget the output target to normalize
+ * @returns an output target that's been normalized
+ */
+export function normalizeOutputTarget(config: Config, outputTarget: any): OutputTargetReact {
   const results: OutputTargetReact = {
     ...outputTarget,
     excludeComponents: outputTarget.excludeComponents || [],

--- a/packages/react-output-target/src/types.ts
+++ b/packages/react-output-target/src/types.ts
@@ -1,3 +1,7 @@
+/**
+ * An output target configuration interface used to configure Stencil to properly generate the bindings necessary to use
+ * Stencil components in a React application
+ */
 export interface OutputTargetReact {
   componentCorePackage?: string;
   proxiesFile: string;
@@ -9,6 +13,9 @@ export interface OutputTargetReact {
   customElementsDir?: string;
 }
 
+/**
+ * Describes the fields of a package.json file necessary to generate the Stencil-React bindings
+ */
 export interface PackageJSON {
   types: string;
 }

--- a/packages/react-output-target/src/utils.ts
+++ b/packages/react-output-target/src/utils.ts
@@ -5,14 +5,30 @@ import type { PackageJSON } from './types';
 
 const readFile = promisify(fs.readFile);
 
+/**
+ * Send a string to lowercase
+ * @param str the string to lowercase
+ * @returns the lowercased string
+ */
 export const toLowerCase = (str: string) => str.toLowerCase();
 
-export const dashToPascalCase = (str: string) =>
+/**
+ * Convert a string using dash-case to PascalCase
+ * @param str the string to convert to PascalCase
+ * @returns the PascalCased string
+ */
+export const dashToPascalCase = (str: string): string =>
   toLowerCase(str)
     .split('-')
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join('');
 
+// TODO(STENCIL-356): Investigate removing this unused function
+/**
+ * Flattens a two-dimensional array into a one dimensional array
+ * @param array the array to flatten
+ * @returns the flattened array
+ */
 export function flatOne<T>(array: T[][]): T[] {
   if (array.flat) {
     return array.flat(1);
@@ -23,7 +39,13 @@ export function flatOne<T>(array: T[][]): T[] {
   }, [] as T[]);
 }
 
-export function sortBy<T>(array: T[], prop: (item: T) => string) {
+/**
+ * Sorts a provided array by a property belonging to an item that exists on each item in the array
+ * @param array the array to sort
+ * @param prop a function to look up a field on an entry in the provided array
+ * @returns a shallow copy of the array, sorted by the property resolved by `prop`
+ */
+export function sortBy<T>(array: ReadonlyArray<T>, prop: (item: T) => string): ReadonlyArray<T>{
   return array.slice().sort((a, b) => {
     const nameA = prop(a);
     const nameB = prop(b);
@@ -33,7 +55,12 @@ export function sortBy<T>(array: T[], prop: (item: T) => string) {
   });
 }
 
-export function normalizePath(str: string) {
+/**
+ * Normalize a path
+ * @param str the path to normalize
+ * @returns the normalized path
+ */
+export function normalizePath(str: string): string {
   // Convert Windows backslash paths to slash paths: foo\\bar ➔ foo/bar
   // https://github.com/sindresorhus/slash MIT
   // By Sindre Sorhus
@@ -64,7 +91,14 @@ export function normalizePath(str: string) {
   return str;
 }
 
-export function relativeImport(pathFrom: string, pathTo: string, ext?: string) {
+/**
+ * Generate the relative import from `pathFrom` to `pathTo`
+ * @param pathFrom the path that shall be used as the origin in determining the relative path
+ * @param pathTo the path that shall be used as the destination in determining the relative path
+ * @param ext an extension to remove from the final path
+ * @returns the derived relative import
+ */
+export function relativeImport(pathFrom: string, pathTo: string, ext?: string): string {
   let relativePath = path.relative(path.dirname(pathFrom), path.dirname(pathTo));
   if (relativePath === '') {
     relativePath = '.';
@@ -74,7 +108,12 @@ export function relativeImport(pathFrom: string, pathTo: string, ext?: string) {
   return normalizePath(`${relativePath}/${path.basename(pathTo, ext)}`);
 }
 
-export async function readPackageJson(rootDir: string) {
+/**
+ * Attempts to read a `package.json` file at the provided directory.
+ * @param rootDir the directory to search for the `package.json` file to read
+ * @returns the read and parsed `package.json` file
+ */
+export async function readPackageJson(rootDir: string): Promise<PackageJSON> {
   const pkgJsonPath = path.join(rootDir, 'package.json');
 
   let pkgJson: string;


### PR DESCRIPTION
this commit adds function-level jsdoc to the react output
wrapper/target. this was done in as a part of an effort to come up to
speed/help others in the same vain.

some type narrowing was performed here, largely to make certain array
types readonly. a conscious decision was made to not make the public
facing api (exposed by src/index.ts) use a ReadonlyArray<T>, so as to
avoid a breaking change (although this may be revisisted in the future)

note that prettier/formatting does not exist in the project today. to avoid
churn now and in the future, I only touched JSDoc to wrap it at 120 lines.
code formatting will come at a later time