### PR TITLE
chore(git): add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 build/
 *.swp
 .DS_Store
+.idea/
 .vscode


### PR DESCRIPTION
changes to .idea/ could be picked up by np otherwise, blocking a
publish. we don't want to encourage flags to bypass this check, so let's
just add it now to the .gitignore and be done with it