### PR TITLE
chore(github): update ci to run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
-name: CI
+name: Build & Test
 
-on: push
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build-and-test-nix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,36 +9,14 @@ on:
       - '**'
 
 jobs:
-  build-and-test-nix:
-    name: Build and Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
-      - uses: actions/checkout@v1
-      - name: Restore Dependency Cache
-        uses: actions/cache@v1
-        id: restore-dependencies
-        with:
-          path: node_modules
-          key: ${{ runner.OS }}-dependency-cache-${{ hashFiles('package-lock.json') }}
+  build_and_test:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'windows-latest' ]
 
-      - name: Install Dependencies
-        run: npm ci
+    name: Node 16 on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-      - name: Setup Testing Environment
-        run: npm run bootstrap
-
-      - name: Build
-        run: npm run build
-
-      - name: Test
-        run: npm test
-  plugin-build-and-test-windows:
-    name: Build and Test
-    runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/setup-node@v1


### PR DESCRIPTION
there are 2 commits in this PR, that I'll likely rebase + merge (rather than squash) to keep them distinct:

1. https://github.com/ionic-team/stencil-ds-output-targets/pull/225/commits/db283849ab6c1d646190d30b20a302ddee1f4212 - this commit will run CI on pull requests (the enforcement needs to be enabled in github after this lands). it also renames the workflow to
match the stencil core repository

The contents of this PR almost exactly matches that found in the [Stencil core CI setup](https://github.com/ionic-team/stencil/blob/1c1500413a9fa6f7be4ec34f78132c2c670680f3/.github/workflows/main.yml#L1-L10), the only difference being branch names

2. https://github.com/ionic-team/stencil-ds-output-targets/pull/225/commits/22b0517c2bc0f0fb2ae82890ac2063919415619b - remove the duplication between the unix + windows workflows by using a strategy.matrix list of OS'es.

I was able to confirm the old windows CI system was the same as Unix with good old fashioned `find` in my IDE, and was able to update accordingly. Tailed the logs to verify everything worked
