### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,13 +40,13 @@ body:
   - type: textarea
     attributes:
       label: Current Behavior
-      description: A clear description of what the bug is and how it manifests.
+      description: A clear description of what the bug is and how it manifests. For example, what does the incorrect output look like?
     validations:
       required: true
   - type: textarea
     attributes:
       label: Expected Behavior
-      description: A clear description of what you expected to happen.
+      description: A clear description of what you expected to happen. For example, what does the correct output look like?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: 🐛 Bug Report
-description: Create a report to help us improve Stencil
+description: Create a report to help us improve the Stencil Framework Output Targets
 title: 'bug: '
 body:
   - type: checkboxes
@@ -11,12 +11,30 @@ body:
           required: true
         - label: I agree to follow the [Code of Conduct](https://github.com/ionic-team/stencil/blob/main/CODE_OF_CONDUCT.md).
           required: true
-        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil/issues) that already report this problem, without success.
+        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil-ds-output-targets/issues) that already report this problem, without success.
           required: true
   - type: input
     attributes:
       label: Stencil Version
       description: The version number of Stencil where the issue is occurring.
+    validations:
+      required: true
+  - type: dropdown
+    id: Stencil Framework Output Target
+    attributes:
+      label: Stencil Framework Output Target
+      description: Which Stencil Framework Output Target are you using?
+      options:
+        - Angular
+        - React
+        - Svelte
+        - Vue
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Stencil Framework Output Target Version
+      description: Which version of Framework Output Target are you using?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: Stencil Framework Output Target
+    id: stencil-framework-output-target
     attributes:
       label: Stencil Framework Output Target
       description: Which Stencil Framework Output Target are you using?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: 🐛 Bug Report
+description: Create a report to help us improve Stencil
+title: 'bug: '
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md).
+          required: true
+        - label: I agree to follow the [Code of Conduct](https://github.com/ionic-team/stencil/blob/main/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil/issues) that already report this problem, without success.
+          required: true
+  - type: input
+    attributes:
+      label: Stencil Version
+      description: The version number of Stencil where the issue is occurring.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A clear description of what the bug is and how it manifests.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Please explain the steps required to duplicate this issue.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Code Reproduction URL
+      description: Please reproduce this issue in a blank Stencil starter application and provide a link to the repo. Run `npm init stencil` to quickly spin up a Stencil project. This is the best way to ensure this issue is triaged quickly. Issues without a code reproduction may be closed if the Stencil Team cannot reproduce the issue you are reporting.
+      placeholder: https://github.com/...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/ionic-team/stencil-site/issues/new/choose
+    about: This issue tracker is not for documentation issues. Please file documentation issues on the Stencil site repo.
+  - name: 💻 Create Stencil CLI
+    url: https://github.com/ionic-team/create-stencil/issues/new/choose
+    about: This issue tracker is not for Create Stencil CLI issues. Please file CLI issues on the Create Stencil CLI repo.
+  - name: 🤔 Support Question
+    url: https://forum.ionicframework.com/
+    about: This issue tracker is not for support questions. Please post your question on the Ionic Forums.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: 💡 Feature Request
+description: Suggest an idea for Stencil
+title: 'feat: '
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md).
+          required: true
+        - label: I agree to follow the [Code of Conduct](https://github.com/ionic-team/stencil/blob/main/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil/issues) that already include this feature request, without success.
+          required: true
+  - type: textarea
+    attributes:
+      label: Describe the Feature Request
+      description: A clear and concise description of what the feature does.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the Use Case
+      description: A clear and concise use case for what problem this feature would solve.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe Preferred Solution
+      description: A clear and concise description of what you how you want this feature to be added to Stencil.
+  - type: textarea
+    attributes:
+      label: Describe Alternatives
+      description: A clear and concise description of any alternative solutions or features you have considered.
+  - type: textarea
+    attributes:
+      label: Related Code
+      description: If you are able to illustrate the feature request with an example, please provide a sample Stencil component(s). Run `npm init stencil` to quickly spin up a Stencil project.
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to implement, Stack Overflow links, forum links, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: 💡 Feature Request
-description: Suggest an idea for Stencil
+description: Suggest an idea for the Stencil Framework Output Targets
 title: 'feat: '
 body:
   - type: checkboxes
@@ -11,7 +11,7 @@ body:
           required: true
         - label: I agree to follow the [Code of Conduct](https://github.com/ionic-team/stencil/blob/main/CODE_OF_CONDUCT.md).
           required: true
-        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil/issues) that already include this feature request, without success.
+        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil-ds-output-targets/issues) that already report this problem, without success.
           required: true
   - type: textarea
     attributes:
@@ -28,7 +28,7 @@ body:
   - type: textarea
     attributes:
       label: Describe Preferred Solution
-      description: A clear and concise description of what you how you want this feature to be added to Stencil.
+      description: A clear and concise description of what you how you want this feature to be added to the Stencil Framework Output Target(s).
   - type: textarea
     attributes:
       label: Describe Alternatives


### PR DESCRIPTION
this pr works towards adding a little more process/structure to
the repo by adding issue and feature request templates to the
repo.  the first commit copies the templates from the Stencil
repo at it's current HEAD ([1c1500413](https://github.com/ionic-team/stencil/tree/1c1500413a9fa6f7be4ec34f78132c2c670680f3))

subsequent commits alter one document at a time to highlight the
changes made.