### PR TITLE
feat: introduce componentNameFormatter for react output target

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,35 @@ If `true`, the output target will import the custom element instance and registe
 
 This is the directory where the custom elements are imported from when using the `[Custom Elements Bundle](https://stenciljs.com/docs/custom-elements)`. Defaults to the `components` directory. Only applies when `includeImportCustomElements` is `true`.
 
+### componentNameFormatter
+
+This is an optional function that will be used to format the component name. It takes two arguments, the first argument is the suggested generated name, and the second option is the component meta. By default, the component name is converted by dash-case to PascalCase.
+
+Example to remove first 3 characters:
+
+```ts
+import { Config } from '@stencil/core';
+import { reactOutputTarget } from '@stencil/react-output-target';
+
+export const config: Config = {
+  namespace: 'demo',
+  outputTargets: [
+    reactOutputTarget({
+      componentCorePackage: 'component-library',
+      proxiesFile: '../component-library-react/src/components.ts',
+      componentNameFormatter: (suggestedName: string) => {
+        return `${suggestedName.substring(3)}`;
+      },
+    }),
+    {
+      type: 'dist',
+    },
+  ],
+};
+```
+
+```
+
 ### Setup of React Component Library
 
 There is an example component library package available on Github so that you can get started. This repo will likely live as a sibling to your Stencil component library. https://github.com/ionic-team/stencil-ds-react-template

--- a/packages/react-output-target/__tests__/generate-react-components.spec.ts
+++ b/packages/react-output-target/__tests__/generate-react-components.spec.ts
@@ -9,7 +9,9 @@ describe('createComponentDefinition', () => {
       tagName: 'my-component',
       methods: [],
       events: [],
-    }, true);
+    }, {
+      includeImportCustomElements: true
+    });
     expect(output[0]).toEqual(`export const MyComponent = /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>('my-component', undefined, undefined, defineMyComponent);`);
   });
 
@@ -19,8 +21,22 @@ describe('createComponentDefinition', () => {
       tagName: 'my-component',
       methods: [],
       events: [],
-    });
+    }, {});
     expect(output[0]).toEqual(`export const MyComponent = /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>('my-component');`);
+  });
+
+  it('should create a React component with a prefix', () => {
+    const output = createComponentDefinition({
+      properties: [],
+      tagName: 'my-component',
+      methods: [],
+      events: [],
+    }, {
+      componentNameFormatter: (suggestedName: string, _) => {
+        return `Prefixed${suggestedName}`;
+      },
+    });
+    expect(output[0]).toEqual(`export const PrefixedMyComponent = /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>('my-component');`);
   });
 });
 

--- a/packages/react-output-target/__tests__/generate-react-components.spec.ts
+++ b/packages/react-output-target/__tests__/generate-react-components.spec.ts
@@ -38,6 +38,49 @@ describe('createComponentDefinition', () => {
     });
     expect(output[0]).toEqual(`export const PrefixedMyComponent = /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>('my-component');`);
   });
+
+  const validFormatters = [
+    (suggestedName: string, _) => `Prefixed${suggestedName}`,
+    (suggestedName: string, _) => `_${suggestedName}`,
+    (suggestedName: string, _) => suggestedName,
+    (suggestedName: string, _) => `$${suggestedName}$`,
+  ];
+
+  test.each(validFormatters)('should for the react component name with valid formatters', (componentNameFormatter) => {
+    createComponentDefinition({
+      properties: [],
+      tagName: 'my-component',
+      methods: [],
+      events: [],
+    }, {
+      componentNameFormatter
+    });
+  });
+
+  const invalidFormatters = [
+    (suggestedName: string, _) => `.${suggestedName}`,
+    (suggestedName: string, _) => `Test ${suggestedName}`,
+    (_suggestedName: string, _) => ``,
+    (_suggestedName: string, _) => ` `,
+    (_suggestedName: string, _) => `eval`,
+    (_suggestedName: string, _) => null,
+    (_suggestedName: string, _) => `x x`,
+    (_suggestedName: string, _) => `no-dashes`,
+  ];
+
+  test.each(invalidFormatters)('should error with an invalid react component name', (componentNameFormatter) => {
+    expect(() => {
+      createComponentDefinition({
+        properties: [],
+        tagName: 'my-component',
+        methods: [],
+        events: [],
+      }, {
+        componentNameFormatter
+      });
+
+    }).toThrowError();
+  });
 });
 
 describe('generateProxies', () => {

--- a/packages/react-output-target/src/output-react.ts
+++ b/packages/react-output-target/src/output-react.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { OutputTargetReact, PackageJSON } from './types';
-import { dashToPascalCase, normalizePath, readPackageJson, relativeImport, sortBy } from './utils';
+import { dashToPascalCase, verifyValidComponentName, normalizePath, readPackageJson, relativeImport, sortBy } from './utils';
 import type {
   CompilerCtx,
   ComponentCompilerMeta,
@@ -52,7 +52,9 @@ function getFilteredComponents(excludeComponents: ReadonlyArray<string> = [], cm
 function componentNameFormatter(component: ComponentCompilerMeta, outputTarget: OutputTargetReact) {
   const tagNameAsPascal = dashToPascalCase(component.tagName);
   if (outputTarget.componentNameFormatter && typeof outputTarget.componentNameFormatter === 'function') {
-    return outputTarget.componentNameFormatter(tagNameAsPascal, component);
+    const formattedName = outputTarget.componentNameFormatter(tagNameAsPascal, component);
+    verifyValidComponentName(formattedName);
+    return formattedName;
   }
   return tagNameAsPascal;
 }

--- a/packages/react-output-target/src/types.ts
+++ b/packages/react-output-target/src/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentCompilerMeta } from "@stencil/core/internal";
+
 /**
  * An output target configuration interface used to configure Stencil to properly generate the bindings necessary to use
  * Stencil components in a React application
@@ -11,6 +13,7 @@ export interface OutputTargetReact {
   includeDefineCustomElements?: boolean;
   includeImportCustomElements?: boolean;
   customElementsDir?: string;
+  componentNameFormatter?: (suggestedName: string, component: ComponentCompilerMeta) => string
 }
 
 /**

--- a/packages/react-output-target/src/utils.ts
+++ b/packages/react-output-target/src/utils.ts
@@ -133,6 +133,74 @@ export async function readPackageJson(rootDir: string): Promise<PackageJSON> {
   return pkgData;
 }
 
+/**
+ * Verify if something is a valid react component name.
+ * @param name the component name to verify
+ * @returns true if it's valid, false if it's invalid.
+ */
+export function verifyValidComponentName(name: string) {
+  if (JAVASCRIPT_RESERVED_WORDS_REGEX.test(name)) {
+    throw new Error('While verifiying the component name "'+name+'" was found to be a reserved javascript word.');
+  }
+
+  if (!VALID_COMPONENT_REGEX.test(name)) {
+    throw new Error('While verifiying the component name "'+name+'" was found to be an invalid react component name, it should match ' + VALID_COMPONENT_REGEX);
+  }
+
+}
+
 const EXTENDED_PATH_REGEX = /^\\\\\?\\/;
+const VALID_COMPONENT_REGEX = /^([A-z]|\$|_)([A-z]|[0-9]|\$|_)*$/i;
 const NON_ASCII_REGEX = /[^\x00-\x80]+/;
 const SLASH_REGEX = /\\/g;
+const JAVASCRIPT_RESERVED_WORDS = [
+  'do',
+  'if',
+  'in',
+  'for',
+  'let',
+  'new',
+  'try',
+  'var',
+  'case',
+  'else',
+  'enum',
+  'eval',
+  'false',
+  'null',
+  'this',
+  'true',
+  'void',
+  'with',
+  'await',
+  'break',
+  'catch',
+  'class',
+  'const',
+  'super',
+  'throw',
+  'while',
+  'yield',
+  'delete',
+  'export',
+  'import',
+  'public',
+  'return',
+  'static',
+  'switch',
+  'typeof',
+  'default',
+  'extends',
+  'finally',
+  'package',
+  'private',
+  'continue',
+  'debugger',
+  'function',
+  'arguments',
+  'interface',
+  'protected',
+  'implements',
+  'instanceof',
+];
+const JAVASCRIPT_RESERVED_WORDS_REGEX = new RegExp('^(?:' + JAVASCRIPT_RESERVED_WORDS.join('|') + ')$')


### PR DESCRIPTION
# Pull request checklist
Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (npm run build) was run locally for affected output targets
- [x] Tests (npm test) were run locally and passed

# Pull request type
Please check the type of change your PR introduces:

- [ ]  Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, renaming)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
- [ ]  - [ ] Documentation content changes
 Other (please describe):

# What is the current behavior?
N/A

# What is the new behavior?
This feature introduces a config option for the react output target called `componentNameFormatter` which allows formatting the name of component names generated in react.

 This is a very useful utility when you don't always want your name for your react package. For example, you may not want your react components to include the prefix, or you may want to add a prefix or suffix.

I have included an example in the `README.md` file.

Also resolves #122

# Does this introduce a breaking change?
- [ ] Yes
- [x] No



