### PR TITLE
chore(): add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Lines starting with '#' are comments.
+
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '\*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+
+# This should make it easy to add new rules without breaking existing ones.
+
+# Global owners
+
+- @ionic-team/framework-core
+- @ionic-team/stencil


### PR DESCRIPTION
Introduces global codeowners for the repository.

When a new PR is opened, both the Framework and Stencil team will be automatically added for review. 