### PR TITLE
chore(): codeowners format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,5 +16,5 @@
 
 # Global owners
 
-- @ionic-team/framework-core
-- @ionic-team/stencil
+* @ionic-team/framework-core
+* @ionic-team/stencil


### PR DESCRIPTION
The format for the codeowners file is not registering global owners correctly. The VSCode formatting on markdown contents reformatted `*` to `-` during my previous PR. 