### PR TITLE
chore(): add ionic issue bot

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -48,26 +48,6 @@ lockClosed:
     If this is still an issue with the latest version of the output targets, please create a new issue and ensure the template is fully filled out.
   dryRun: false
 
-stale:
-  days: 365
-  maxIssuesPerRun: 100
-  exemptLabels:
-    - "good first issue"
-    - "triage"
-    - "type: bug"
-    - "type: feature request"
-  exemptAssigned: true
-  exemptProjects: true
-  exemptMilestones: true
-  label: "ionitron: stale issue"
-  message: >
-    Thanks for the issue! This issue is being closed due to inactivity. If this is still
-    an issue with the latest version of the output targets, please create a new issue and ensure the
-    template is fully filled out.
-  close: true
-  lock: true
-  dryRun: false
-
 noReply:
   days: 14
   maxIssuesPerRun: 100

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,0 +1,99 @@
+triage:
+  label: triage
+  removeLabelWhenProjectAssigned: true
+  dryRun: false
+
+comment:
+  labels:
+    - label: "help wanted"
+      message: >
+        This issue has been labeled as `help wanted`. This label is added to issues
+        that we believe would be good for contributors.
+
+
+        If you'd like to work on this issue, please comment here letting us know that
+        you would like to submit a pull request for it. This helps us to keep track of
+        the pull request and make sure there isn't duplicated effort.
+
+        Thank you!
+    - label: "ionitron: needs reproduction"
+      message: >
+        Thanks for the issue! This issue has been labeled as `needs reproduction`. This label
+        is added to issues that need a code reproduction.
+
+
+        Please reproduce this issue in a Stencil project and provide a way for us to access it (GitHub repo, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve the issue, leading to it being closed.
+
+
+        If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was not enough for our team to reproduce the issue.
+
+  dryRun: false
+
+closeAndLock:
+  labels:
+    - label: "ionitron: missing template"
+      message: >
+        Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
+        template in order to gather more information and further assist you. Please create a new issue and ensure the
+        template is fully filled out.
+  close: true
+  lock: true
+  dryRun: false
+
+lockClosed:
+  days: 30
+  maxIssuesPerRun: 100
+  message: >
+    Thanks for the issue! This issue is being locked to prevent comments that are not relevant to the original issue.
+    If this is still an issue with the latest version of the output targets, please create a new issue and ensure the template is fully filled out.
+  dryRun: false
+
+stale:
+  days: 365
+  maxIssuesPerRun: 100
+  exemptLabels:
+    - "good first issue"
+    - "triage"
+    - "type: bug"
+    - "type: feature request"
+  exemptAssigned: true
+  exemptProjects: true
+  exemptMilestones: true
+  label: "ionitron: stale issue"
+  message: >
+    Thanks for the issue! This issue is being closed due to inactivity. If this is still
+    an issue with the latest version of the output targets, please create a new issue and ensure the
+    template is fully filled out.
+  close: true
+  lock: true
+  dryRun: false
+
+noReply:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "needs: reply"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a reply. If this is still
+    an issue with the latest version of the output targets, please create a new issue and ensure the
+    template is fully filled out.
+  close: true
+  lock: true
+  dryRun: false
+
+noReproduction:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "ionitron: needs reproduction"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
+    an issue with the latest version of the output targets, please create a new issue and ensure the
+    template is fully filled out.
+  close: true
+  lock: true
+  dryRun: false


### PR DESCRIPTION
Adds the Ionitron (ionic issue bot) to the repository to aid with repository management. 