### PR TITLE
fix(vue): add correct InputProp types

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -1,6 +1,6 @@
 import { VNode, defineComponent, getCurrentInstance, h, inject, ref, Ref } from 'vue';
 
-export interface InputProps extends Object {
+export interface InputProps {
   modelValue?: string | boolean;
 }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: See https://github.com/ionic-team/ionic-framework/issues/25485

In Vue 3.0.0, prop types defaulted to `any`. In Vue 3.0.1 they defaulted to `{}`. https://github.com/vuejs/core/commit/6aa2256913bfd097500aba83b78482b87107c101

Ionic recently updated dev deps to build with Vue 3.2.x (previously, we were using Vue 3.0.0).

This uncovered an issue where all component props had incorrect types: 

```typescript
export declare const IonLabel: import("vue").DefineComponent<JSX.IonLabel & import("./vue-component-lib/utils").InputProps, object, {}, import("vue").ComputedOptions, import("vue").MethodOptions, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, Record<string, any>, string, import("vue").VNodeProps & import("vue").AllowedComponentProps & import("vue").ComponentCustomProps, Readonly<{} & {
    toString?: string;
    valueOf?: unknown;
    toLocaleString?: string;
    color?: import("@ionic/core").Color;
    position?: "fixed" | "stacked" | "floating";
    mode?: "ios" | "md";
    constructor?: Function;
    modelValue?: string | boolean;
    hasOwnProperty?: (v: PropertyKey) => boolean;
    isPrototypeOf?: (v: Object) => boolean;
    propertyIsEnumerable?: (v: PropertyKey) => boolean;
}>, {}>;
```

Note that `toString`, `valueOf`, and `toLocaleString` types should be functions that return strings. This was caused by `InputProps` extending `Object`. We never caught it because test apps were being built with Vue 3.0.0 which essentially turned off type checking with its usage of `any`.

Additionally, our test apps were using Vue CLI + Webpack, and this issue seems to only impact Vite.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Do not extend from `Object`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
