### PR TITLE
fix(angular): type resolution with strict templates

### DIFF
--- a/packages/angular-output-target/angular-component-lib/utils.ts
+++ b/packages/angular-output-target/angular-component-lib/utils.ts
@@ -46,14 +46,18 @@ export const defineCustomElement = (tagName: string, customElement: any) => {
 const NG_COMP_DEF = 'ɵcmp';
 
 export const clearAngularOutputBindings = (cls: any) => {
-  const instance = cls.prototype.constructor;
-  if (instance[NG_COMP_DEF]) {
-    /**
-     * With the output targets generating @Output() proxies, we need to
-     * clear the metadata (ɵcmp.outputs) so that Angular does not add its own event listener
-     * and cause duplicate event emissions for the web component events.
-     */
-    instance[NG_COMP_DEF].outputs = {};
+  if (typeof cls === 'object' && cls !== null) {
+    if (cls.prototype.constructor) {
+      const instance = cls.prototype.constructor;
+      if (instance[NG_COMP_DEF]) {
+        /**
+         * With the output targets generating @Output() proxies, we need to
+         * clear the metadata (ɵcmp.outputs) so that Angular does not add its own event listener
+         * and cause duplicate event emissions for the web component events.
+         */
+        instance[NG_COMP_DEF].outputs = {};
+      }
+    }
   }
 };
 

--- a/packages/angular-output-target/angular-component-lib/utils.ts
+++ b/packages/angular-output-target/angular-component-lib/utils.ts
@@ -43,6 +43,10 @@ export const defineCustomElement = (tagName: string, customElement: any) => {
   }
 }
 
+/**
+ * The Angular property name that contains the object of metadata properties
+ * for the component added by the Angular compiler.
+ */
 const NG_COMP_DEF = 'ɵcmp';
 
 export const clearAngularOutputBindings = (cls: any) => {

--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -39,7 +39,7 @@
     "@angular/forms": "8.2.14"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.9.0"
+    "@stencil/core": "^2.16.0"
   },
   "jest": {
     "transform": {

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -61,7 +61,7 @@ export const createComponentDefinition = (
    */
   const outputBindings: string[]  = [
     ''
-];
+  ];
 
   // Generate outputs
   outputs.forEach((output, index) => {

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -59,9 +59,7 @@ export const createComponentDefinition = (
   /**
    * The list of @Output() bindings to generate for the component.
    */
-  const outputBindings: string[]  = [
-    ''
-  ];
+  const outputBindings: string[]  = [];
 
   // Generate outputs
   outputs.forEach((output, index) => {
@@ -119,7 +117,7 @@ ${getProxyCmp(
 })
 export class ${tagNameAsPascal} {`,
   ];
-  lines.push(...outputBindings);
+  lines.push('\n', ...outputBindings);
   lines.push('  protected el: HTMLElement;');
   lines.push(`  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -1,4 +1,4 @@
-import { dashToPascalCase, normalizePath } from './utils';
+import { dashToPascalCase, formatCustomEventInterfaceName, normalizePath } from './utils';
 import type { ComponentCompilerMeta } from '@stencil/core/internal';
 
 export const createComponentDefinition = (
@@ -79,7 +79,14 @@ export const createComponentDefinition = (
       .replace(/\n/g, ' ')
       .replace(/\s{2,}/g, ' ')
       .replace(/,\s*/g, ', '));
-    componentEvents.push(`  ${output.name}: EventEmitter<CustomEvent<${outputTypeRemapped.trim()}>>;`);
+
+    /**
+     * Starting in Stencil 2.16.0, the compiler will generate a CustomEvent interface
+     * for each component with custom events.
+     *
+     * The name of this custom event is "ComponentTagNameCustomEvent".
+     */
+    componentEvents.push(`  ${output.name}: EventEmitter<${formatCustomEventInterfaceName(cmpMeta.tagName)}<${outputTypeRemapped.trim()}>>;`);
 
     if (index === outputs.length - 1) {
       // Empty line to push end `}` to new line

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -56,6 +56,13 @@ export const createComponentDefinition = (
     '' // Empty first line
   ];
 
+  /**
+   * The list of @Output() bindings to generate for the component.
+   */
+  const outputBindings: string[]  = [
+    ''
+];
+
   // Generate outputs
   outputs.forEach((output, index) => {
     componentEvents.push(
@@ -87,10 +94,12 @@ export const createComponentDefinition = (
      * The name of this custom event is "ComponentTagNameCustomEvent".
      */
     componentEvents.push(`  ${output.name}: EventEmitter<${formatCustomEventInterfaceName(cmpMeta.tagName)}<${outputTypeRemapped.trim()}>>;`);
+    outputBindings.push(`  @Output() ${output.name} = new EventEmitter<${formatCustomEventInterfaceName(cmpMeta.tagName)}<${outputTypeRemapped.trim()}>>();`);
 
     if (index === outputs.length - 1) {
       // Empty line to push end `}` to new line
       componentEvents.push('\n');
+      outputBindings.push('\n');
     }
   });
 
@@ -110,7 +119,7 @@ ${getProxyCmp(
 })
 export class ${tagNameAsPascal} {`,
   ];
-
+  lines.push(...outputBindings);
   lines.push('  protected el: HTMLElement;');
   lines.push(`  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -72,7 +72,7 @@ export function generateProxies(
 
   const imports = `/* tslint:disable */
 /* auto-generated angular directive proxies */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone, Output } from '@angular/core';
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';\n`;
 
   const importLocation = getImportPackageName(outputTarget, componentsTypeFile);

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -117,7 +117,7 @@ import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';\n`;
 
       return `import { defineCustomElement as define${pascalImport} } from '${normalizePath(outputTarget.componentCorePackage!)}/${outputTarget.customElementsDir ||
         'components'
-        }/${component.tagName}.js';`;
+      }/${component.tagName}.js';`;
     });
 
     sourceImports = cmpImports.join('\n');

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -92,7 +92,7 @@ import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';\n`;
    * Stencil 2.16.0. We import these interfaces so they can be used in the generate
    * functions for the @Output() events.
    */
-  const customEventInterfaces = components.filter(c => c.events.filter(e => !e.internal).length > 0).map(c => {
+  const customEventInterfaces = components.filter(c => c.events.find(e => !e.internal) !== undefined).map(c => {
     return formatCustomEventInterfaceName(c.tagName);
   });
 

--- a/packages/angular-output-target/src/utils.ts
+++ b/packages/angular-output-target/src/utils.ts
@@ -85,6 +85,17 @@ export async function readPackageJson(config: Config, rootDir: string) {
   return pkgData;
 }
 
+/**
+ * Returns the formatted custom event interface name for the component.
+ * With a tag of "my-cmp", it will return "MyCmpCustomEvent".
+ *
+ * @param componentTagName The tag selector of the component (i.e. my-cmp)
+ * @returns The formatted custom event interface name.
+ */
+export function formatCustomEventInterfaceName(componentTagName: string) {
+  return `${dashToPascalCase(componentTagName)}CustomEvent`;
+}
+
 const EXTENDED_PATH_REGEX = /^\\\\\?\\/;
 const NON_ASCII_REGEX = /[^\x00-\x80]+/;
 const SLASH_REGEX = /\\/g;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

The generated Angular proxies do not take advantage of the new custom event interfaces as of Stencil 2.16.0. 

<!-- Issues are required for both bug fixes and features. -->

Issue URL: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Requires a peer dependency of `@stencil/core@2.16.0`
- Generates Angular output events with the new custom event interfaces
- Angular strict templates should no longer complain for output bindings

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Requires Stencil 2.16.0. Developers will need to update their library dependency version to minimally `2.16.0`. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `0.6.1-dev.11655499531.137e1d26`