### PR TITLE
fix(vue): update v-model type and allow for custom type signature

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -1,7 +1,7 @@
 import { VNode, defineComponent, getCurrentInstance, h, inject, ref, Ref } from 'vue';
 
-export interface InputProps {
-  modelValue?: string | boolean;
+export interface InputProps<T> {
+  modelValue?: T;
 }
 
 const UPDATE_VALUE_EVENT = 'update:modelValue';
@@ -49,7 +49,7 @@ const getElementClasses = (ref: Ref<HTMLElement | undefined>, componentClasses: 
 * @prop externalModelUpdateEvent - The external event to fire from your Vue component when modelUpdateEvent fires. This is used for ensuring that v-model references have been
 * correctly updated when a user's event callback fires.
 */
-export const defineContainer = <Props>(
+export const defineContainer = <Props, VModelType=string|number|boolean>(
   name: string,
   defineCustomElement: any,
   componentProps: string[] = [],
@@ -67,7 +67,7 @@ export const defineContainer = <Props>(
     defineCustomElement();
   }
 
-  const Container = defineComponent<Props & InputProps>((props: any, { attrs, slots, emit }) => {
+  const Container = defineComponent<Props & InputProps<VModelType>>((props: any, { attrs, slots, emit }) => {
     let modelPropValue = props[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
@@ -76,7 +76,7 @@ export const defineContainer = <Props>(
       if (vnode.el) {
         const eventsNames = Array.isArray(modelUpdateEvent) ? modelUpdateEvent : [modelUpdateEvent];
         eventsNames.forEach((eventName: string) => {
-          vnode.el.addEventListener(eventName.toLowerCase(), (e: Event) => {
+          vnode.el!.addEventListener(eventName.toLowerCase(), (e: Event) => {
             modelPropValue = (e?.target as any)[modelProp];
             emit(UPDATE_VALUE_EVENT, modelPropValue);
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

The accepted type signature of `v-model` is hard set to `string | boolean | undefined`. This types is not configurable in the implementation and does not support components that allow a number to be assigned to `v-model`. 

Issue URL: https://github.com/ionic-team/ionic-framework/issues/25575

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the default type signature of `v-model` to be `string | number | boolean | undefined`
- Updates the `defineContainer` function to accept a type to use as the `v-model` type (future work is to make the framework wrappers use the type of `value` from the web component as the type signature)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `0.6.1-dev.11657573317.16e0205c`
