### PR TITLE
feat(angular): proxyDeclarationFile to generate proxies file

### DIFF
--- a/packages/angular-output-target/__tests__/plugin.spec.ts
+++ b/packages/angular-output-target/__tests__/plugin.spec.ts
@@ -13,7 +13,7 @@ describe('normalizeOutputTarget', () => {
     }).toThrow(new Error('rootDir is not set and it should be set by stencil itself'));
   });
 
-  it('should throw an error if proxyDeclarationFile is not set', () => {
+  it('should throw an error if proxyDeclarationFile and directivesProxyFile is not set', () => {
     expect(() => {
       normalizeOutputTarget(config, {});
     }).toThrow(new Error('proxyDeclarationFile is required. Please set it in the Stencil config.'));

--- a/packages/angular-output-target/__tests__/plugin.spec.ts
+++ b/packages/angular-output-target/__tests__/plugin.spec.ts
@@ -13,19 +13,19 @@ describe('normalizeOutputTarget', () => {
     }).toThrow(new Error('rootDir is not set and it should be set by stencil itself'));
   });
 
-  it('should return fail if proxiesFile is not set', () => {
+  it('should throw an error if proxyDeclarationFile is not set', () => {
     expect(() => {
       normalizeOutputTarget(config, {});
-    }).toThrow(new Error('directivesProxyFile is required'));
+    }).toThrow(new Error('proxyDeclarationFile is required. Please set it in the Stencil config.'));
   });
 
   it('should return defaults for excludeComponents and valueAccessorConfig', () => {
     const results: OutputTargetAngular = normalizeOutputTarget(config, {
-      directivesProxyFile: '/component-library-angular/src/components.ts',
+      proxyDeclarationFile: '/component-library-angular/src/components.ts',
     });
 
     expect(results).toEqual({
-      directivesProxyFile: '/component-library-angular/src/components.ts',
+      proxyDeclarationFile: '/component-library-angular/src/components.ts',
       excludeComponents: [],
       valueAccessorConfig: [],
     } as OutputTargetAngular);

--- a/packages/angular-output-target/src/generate-angular-directives-file.ts
+++ b/packages/angular-output-target/src/generate-angular-directives-file.ts
@@ -12,7 +12,8 @@ export function generateAngularDirectivesFile(
     return Promise.resolve();
   }
 
-  const proxyPath = relativeImport(outputTarget.directivesArrayFile, outputTarget.directivesProxyFile, '.ts');
+  const proxyFile = outputTarget.proxyDeclarationFile ?? outputTarget.directivesProxyFile;
+  const proxyPath = relativeImport(outputTarget.directivesArrayFile, proxyFile, '.ts');
   const directives = components
     .map((cmpMeta) => dashToPascalCase(cmpMeta.tagName))
     .map((className) => `d.${className}`)

--- a/packages/angular-output-target/src/generate-value-accessors.ts
+++ b/packages/angular-output-target/src/generate-value-accessors.ts
@@ -22,7 +22,8 @@ export default async function generateValueAccessors(
     return;
   }
 
-  const targetDir = path.dirname(outputTarget.directivesProxyFile);
+  const proxyFile = outputTarget.proxyDeclarationFile ?? outputTarget.directivesProxyFile;
+  const targetDir = path.dirname(proxyFile);
 
   const normalizedValueAccessors: NormalizedValueAccessors = outputTarget.valueAccessorConfigs.reduce(
     (allAccessors, va) => {

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -15,11 +15,12 @@ export async function angularDirectiveProxyOutput(
   const filteredComponents = getFilteredComponents(outputTarget.excludeComponents, components);
   const rootDir = config.rootDir as string;
   const pkgData = await readPackageJson(config, rootDir);
+  const proxyFile = outputTarget.proxyDeclarationFile ?? outputTarget.directivesProxyFile;
 
   const finalText = generateProxies(filteredComponents, pkgData, outputTarget, config.rootDir as string);
 
   await Promise.all([
-    compilerCtx.fs.writeFile(outputTarget.directivesProxyFile, finalText),
+    compilerCtx.fs.writeFile(proxyFile, finalText),
     copyResources(config, outputTarget),
     generateAngularDirectivesFile(compilerCtx, filteredComponents, outputTarget),
     generateValueAccessors(compilerCtx, filteredComponents, outputTarget, config),
@@ -35,7 +36,8 @@ async function copyResources(config: Config, outputTarget: OutputTargetAngular) 
     throw new Error('stencil is not properly initialized at this step. Notify the developer');
   }
   const srcDirectory = path.join(__dirname, '..', 'angular-component-lib');
-  const destDirectory = path.join(path.dirname(outputTarget.directivesProxyFile), 'angular-component-lib');
+  const proxyFile = outputTarget.proxyDeclarationFile ?? outputTarget.directivesProxyFile;
+  const destDirectory = path.join(path.dirname(proxyFile), 'angular-component-lib');
 
   return config.sys.copy(
     [
@@ -58,7 +60,8 @@ export function generateProxies(
 ) {
   const distTypesDir = path.dirname(pkgData.types);
   const dtsFilePath = path.join(rootDir, distTypesDir, GENERATED_DTS);
-  const componentsTypeFile = relativeImport(outputTarget.directivesProxyFile, dtsFilePath, '.d.ts');
+  const proxyFile = outputTarget.proxyDeclarationFile ?? outputTarget.directivesProxyFile;
+  const componentsTypeFile = relativeImport(proxyFile, dtsFilePath, '.d.ts');
 
   const imports = `/* tslint:disable */
 /* auto-generated angular directive proxies */

--- a/packages/angular-output-target/src/plugin.ts
+++ b/packages/angular-output-target/src/plugin.ts
@@ -29,12 +29,17 @@ export function normalizeOutputTarget(config: Config, outputTarget: any) {
   if (config.rootDir == null) {
     throw new Error('rootDir is not set and it should be set by stencil itself');
   }
-  if (outputTarget.directivesProxyFile == null) {
-    throw new Error('directivesProxyFile is required');
+
+  if (outputTarget.proxyDeclarationFile == null && outputTarget.directivesProxyFile == null) {
+    throw new Error('proxyDeclarationFile is required. Please set it in the Stencil config.');
   }
 
   if (outputTarget.directivesProxyFile && !path.isAbsolute(outputTarget.directivesProxyFile)) {
     results.directivesProxyFile = normalizePath(path.join(config.rootDir, outputTarget.directivesProxyFile));
+  }
+
+  if (outputTarget.proxyDeclarationFile && !path.isAbsolute(outputTarget.proxyDeclarationFile)) {
+    results.proxyDeclarationFile = normalizePath(path.join(config.rootDir, outputTarget.proxyDeclarationFile));
   }
 
   if (outputTarget.directivesArrayFile && !path.isAbsolute(outputTarget.directivesArrayFile)) {

--- a/packages/angular-output-target/src/types.ts
+++ b/packages/angular-output-target/src/types.ts
@@ -1,8 +1,17 @@
 export interface OutputTargetAngular {
   componentCorePackage?: string;
-  directivesProxyFile: string;
+  /**
+   * The relative path from the root directory of the Stencil library to the proxy file that will be generated.
+   *
+   * @deprecated Use `proxyDeclarationFile` instead. This property will be removed in an upcoming release.
+   */
+  directivesProxyFile?: string;
   directivesArrayFile?: string;
   directivesUtilsFile?: string;
+  /**
+   * The relative path from the root directory of the Stencil library to the proxy file that will be generated.
+   */
+  proxyDeclarationFile: string;
   valueAccessorConfigs?: ValueAccessorConfig[];
   excludeComponents?: string[];
   includeImportCustomElements?: boolean;

--- a/packages/angular-output-target/src/types.ts
+++ b/packages/angular-output-target/src/types.ts
@@ -1,7 +1,8 @@
 export interface OutputTargetAngular {
   componentCorePackage?: string;
   /**
-   * The relative path from the root directory of the Stencil library to the proxy file that will be generated.
+   * The path to the proxy file that will be generated. This can be an absolute path
+   * or a relative path from the root directory of the Stencil library.
    *
    * @deprecated Use `proxyDeclarationFile` instead. This property will be removed in an upcoming release.
    */
@@ -9,7 +10,8 @@ export interface OutputTargetAngular {
   directivesArrayFile?: string;
   directivesUtilsFile?: string;
   /**
-   * The relative path from the root directory of the Stencil library to the proxy file that will be generated.
+   * The path to the proxy file that will be generated. This can be an absolute path
+   * or a relative path from the root directory of the Stencil library.
    */
   proxyDeclarationFile: string;
   valueAccessorConfigs?: ValueAccessorConfig[];


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

N/A - adding the initial API changes for supporting SCAM modules in the Angular output target.

Issue URL: Internal

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduces `proxyDeclarationFile` to the Angular output target config API
- Deprecates `directivesProxyFile` (usage will fallback to this property, if set)

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Due to the type change on the `OutputTargetAngular`, `directivesProxyFile` is now optional (up until it is removed) and the new `proxyDeclarationFile` is required. 

Once the SCAM feature is released, developers will need to migrate their stencil config from using `directivesProxyFile` to using the `proxyDeclarationFile` property. Otherwise they will receive a build error when TSC compiles the `stencil.config.ts` file.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Note: This PR is merging back into another feature branch.
