### PR TITLE
fix(angular-output-target): escape kebab-case event names

### DIFF
--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -247,6 +247,21 @@ describe('createComponentTypeDefinition()', () => {
         tags: [],
       },
     },
+    {
+      name: 'my-kebab-event',
+      complexType: {
+        references: {
+          MyKebabEvent: {
+            location: 'import',
+          },
+        },
+        original: 'MyKebabEvent',
+      },
+      docs: {
+        text: '',
+        tags: [],
+      },
+    },
   ];
 
   describe('www build', () => {
@@ -257,6 +272,7 @@ describe('createComponentTypeDefinition()', () => {
         `import type { MyEvent as IMyComponentMyEvent } from '@ionic/core';
 import type { MyOtherEvent as IMyComponentMyOtherEvent } from '@ionic/core';
 import type { MyDoclessEvent as IMyComponentMyDoclessEvent } from '@ionic/core';
+import type { MyKebabEvent as IMyComponentMyKebabEvent } from '@ionic/core';
 
 export declare interface MyComponent extends Components.MyComponent {
   /**
@@ -269,6 +285,8 @@ export declare interface MyComponent extends Components.MyComponent {
   myOtherEvent: EventEmitter<CustomEvent<IMyComponentMyOtherEvent>>;
 
   myDoclessEvent: EventEmitter<CustomEvent<IMyComponentMyDoclessEvent>>;
+
+  'my-kebab-event': EventEmitter<CustomEvent<IMyComponentMyKebabEvent>>;
 }`
       );
     });
@@ -289,6 +307,7 @@ export declare interface MyComponent extends Components.MyComponent {
           `import type { MyEvent as IMyComponentMyEvent } from '@ionic/core/custom-elements';
 import type { MyOtherEvent as IMyComponentMyOtherEvent } from '@ionic/core/custom-elements';
 import type { MyDoclessEvent as IMyComponentMyDoclessEvent } from '@ionic/core/custom-elements';
+import type { MyKebabEvent as IMyComponentMyKebabEvent } from '@ionic/core/custom-elements';
 
 export declare interface MyComponent extends Components.MyComponent {
   /**
@@ -301,6 +320,8 @@ export declare interface MyComponent extends Components.MyComponent {
   myOtherEvent: EventEmitter<CustomEvent<IMyComponentMyOtherEvent>>;
 
   myDoclessEvent: EventEmitter<CustomEvent<IMyComponentMyDoclessEvent>>;
+
+  'my-kebab-event': EventEmitter<CustomEvent<IMyComponentMyKebabEvent>>;
 }`
         );
       });
@@ -314,6 +335,7 @@ export declare interface MyComponent extends Components.MyComponent {
           `import type { MyEvent as IMyComponentMyEvent } from '@ionic/core/components';
 import type { MyOtherEvent as IMyComponentMyOtherEvent } from '@ionic/core/components';
 import type { MyDoclessEvent as IMyComponentMyDoclessEvent } from '@ionic/core/components';
+import type { MyKebabEvent as IMyComponentMyKebabEvent } from '@ionic/core/components';
 
 export declare interface MyComponent extends Components.MyComponent {
   /**
@@ -326,6 +348,8 @@ export declare interface MyComponent extends Components.MyComponent {
   myOtherEvent: EventEmitter<CustomEvent<IMyComponentMyOtherEvent>>;
 
   myDoclessEvent: EventEmitter<CustomEvent<IMyComponentMyDoclessEvent>>;
+
+  'my-kebab-event': EventEmitter<CustomEvent<IMyComponentMyKebabEvent>>;
 }`
         );
       });

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -150,7 +150,7 @@ export const createComponentTypeDefinition = (
   const eventTypes = publicEvents.map((event) => {
     const comment = createDocComment(event.docs);
     let eventName = event.name;
-    if (event.name.indexOf('-') !== -1) {
+    if (event.name.includes('-')) {
       // If an event name includes a dash, we need to wrap it in quotes.
       // https://github.com/ionic-team/stencil-ds-output-targets/issues/212
       eventName = `'${event.name}'`;

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -149,8 +149,14 @@ export const createComponentTypeDefinition = (
   });
   const eventTypes = publicEvents.map((event) => {
     const comment = createDocComment(event.docs);
+    let eventName = event.name;
+    if (event.name.indexOf('-') !== -1) {
+      // If an event name includes a dash, we need to wrap it in quotes.
+      // https://github.com/ionic-team/stencil-ds-output-targets/issues/212
+      eventName = `'${event.name}'`;
+    }
     return `${comment.length > 0 ? `  ${comment}` : ''}
-  ${event.name}: EventEmitter<CustomEvent<${formatOutputType(tagNameAsPascal, event)}>>;`;
+  ${eventName}: EventEmitter<CustomEvent<${formatOutputType(tagNameAsPascal, event)}>>;`;
   });
   const interfaceDeclaration = `export declare interface ${tagNameAsPascal} extends Components.${tagNameAsPascal} {`;
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Kebab-case event names do not generate proxies correctly. 

Issue URL: #212

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Kebab-case event names are escaped, allowing the angular output target to correctly generate the component proxies.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
