### PR TITLE
fix(angular-output-target): type resolution with strict templates

### DIFF
--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -1,3 +1,4 @@
+import { ComponentCompilerEvent } from '@stencil/core/internal';
 import { createComponentTypeDefinition, createAngularComponentDefinition } from '../src/generate-angular-component';
 
 describe('createAngularComponentDefinition()', () => {
@@ -48,7 +49,32 @@ export class MyComponent {
       const component = createAngularComponentDefinition(
         'my-component',
         [],
-        ['my-output', 'my-other-output'],
+        [
+          {
+            name: 'myOutput',
+            complexType: {
+              references: {
+                MyEvent: {
+                  location: 'import',
+                },
+              },
+              original: 'MyEvent',
+              resolved: 'MyEvent',
+            },
+          } as any,
+          {
+            name: 'myOtherOutput',
+            complexType: {
+              references: {
+                MyOtherOutput: {
+                  location: 'import',
+                },
+              },
+              original: 'MyEvent',
+              resolved: 'MyEvent',
+            },
+          } as any,
+        ],
         [],
         false
       );
@@ -63,11 +89,13 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
+  @Output() myOutput: EventEmitter<CustomEvent<IMyComponentMyEvent>> = new EventEmitter();
+  @Output() myOtherOutput: EventEmitter<CustomEvent<IMyComponentMyEvent>> = new EventEmitter();
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['my-output', 'my-other-output']);
+    proxyOutputs(this, this.el, ['myOutput', 'myOtherOutput']);
   }
 }`);
     });
@@ -145,7 +173,32 @@ export class MyComponent {
       const component = createAngularComponentDefinition(
         'my-component',
         [],
-        ['my-output', 'my-other-output'],
+        [
+          {
+            name: 'myOutput',
+            complexType: {
+              references: {
+                MyEvent: {
+                  location: 'import',
+                },
+              },
+              original: 'MyEvent',
+              resolved: 'MyEvent',
+            },
+          } as any,
+          {
+            name: 'myOtherOutput',
+            complexType: {
+              references: {
+                MyOtherOutput: {
+                  location: 'import',
+                },
+              },
+              original: 'MyEvent',
+              resolved: 'MyEvent',
+            },
+          } as any,
+        ],
         [],
         true
       );
@@ -160,11 +213,13 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
+  @Output() myOutput: EventEmitter<CustomEvent<IMyComponentMyEvent>> = new EventEmitter();
+  @Output() myOtherOutput: EventEmitter<CustomEvent<IMyComponentMyEvent>> = new EventEmitter();
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['my-output', 'my-other-output']);
+    proxyOutputs(this, this.el, ['myOutput', 'myOtherOutput']);
   }
 }`);
     });

--- a/packages/angular-output-target/angular-component-lib/utils.ts
+++ b/packages/angular-output-target/angular-component-lib/utils.ts
@@ -36,6 +36,28 @@ export const defineCustomElement = (tagName: string, customElement: any) => {
   }
 };
 
+/**
+ * The Angular property name that contains the object of metadata properties
+ * for the component added by the Angular compiler.
+ */
+const NG_COMP_DEF = 'ɵcmp';
+
+export const clearAngularOutputBindings = (cls: any) => {
+  if (typeof cls === 'function' && cls !== null) {
+    if (cls.prototype.constructor) {
+      const instance = cls.prototype.constructor;
+      if (instance[NG_COMP_DEF]) {
+        /**
+         * With the output targets generating @Output() proxies, we need to
+         * clear the metadata (ɵcmp.outputs) so that Angular does not add its own event listener
+         * and cause duplicate event emissions for the web component events.
+         */
+        instance[NG_COMP_DEF].outputs = {};
+      }
+    }
+  }
+};
+
 // tslint:disable-next-line: only-arrow-functions
 export function ProxyCmp(opts: { defineCustomElementFn?: () => void; inputs?: any; methods?: any }) {
   const decorator = function (cls: any) {
@@ -44,6 +66,8 @@ export function ProxyCmp(opts: { defineCustomElementFn?: () => void; inputs?: an
     if (defineCustomElementFn !== undefined) {
       defineCustomElementFn();
     }
+
+    clearAngularOutputBindings(cls);
 
     if (inputs) {
       proxyInputs(cls, inputs);

--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -42,7 +42,7 @@
     "@angular/forms": "8.2.14"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.16.0"
+    "@stencil/core": "^2.9.0"
   },
   "jest": {
     "transform": {

--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -42,7 +42,7 @@
     "@angular/forms": "8.2.14"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.9.0"
+    "@stencil/core": "^2.16.0"
   },
   "jest": {
     "transform": {

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -31,8 +31,6 @@ export const createAngularComponentDefinition = (
   const formattedOutputs = formatToQuotedList(outputs.map((event) => event.name));
   // Formats the method strings into comma separated, single quoted values.
   const formattedMethods = formatToQuotedList(methods);
-  // The collection of @Output() decorators for the component.
-  const outputDecorators = outputs.map((event) => createAngularOutputDecorator(tagName, event));
 
   const proxyCmpOptions = [];
 
@@ -68,9 +66,9 @@ export const createAngularComponentDefinition = (
     `export class ${tagNameAsPascal} {`,
   ];
 
-  if (outputDecorators.length > 0) {
-    for (let outputDecorator of outputDecorators) {
-      output.push(`  ${outputDecorator}`);
+  if (hasOutputs) {
+    for (let compilerEvent of outputs) {
+      output.push(`  ${createAngularOutputDecorator(tagName, compilerEvent)}`);
     }
   }
 

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { CompilerCtx, ComponentCompilerMeta, Config } from '@stencil/core/internal';
+import type { CompilerCtx, ComponentCompilerEvent, ComponentCompilerMeta, Config } from '@stencil/core/internal';
 import type { OutputTargetAngular, PackageJSON } from './types';
 import {
   relativeImport,
@@ -77,6 +77,7 @@ export function generateProxies(
     'ElementRef',
     'EventEmitter',
     'NgZone',
+    'Output',
   ];
 
   /**
@@ -151,10 +152,10 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
 
     inputs.sort();
 
-    const outputs: string[] = [];
+    const outputs: ComponentCompilerEvent[] = [];
 
     if (cmpMeta.events) {
-      outputs.push(...cmpMeta.events.filter(filterInternalProps).map(mapPropName));
+      outputs.push(...cmpMeta.events.filter(filterInternalProps));
     }
 
     const methods: string[] = [];


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Angular generated output bindings do not correctly detect the custom event types.

Issue URL: #303, #219

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Clears the Angular metadata for each generated `@Output()`
  - This prevents Angular from creating its own event listener/subject (prevents duplicate event emissions)
  - This adds support for custom events to be registered with Angular Language Service
- Reworked how the text output is created. Maintaining spacing and line breaks became too complex with using string interpolation

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR supersedes https://github.com/ionic-team/stencil-ds-output-targets/pull/266. The behavior is _slightly different_. 266 attempted to make use of the new generic interface we generate with Stencil. These interfaces are not exported by default, so we cannot rely on trying to import them from the source project (unless we added some sort of flag + docs for developers to use it). I opted against this for now. We can re-evaluate adding support for that type when v3 of Stencil ships. 

By not using that generic interface, the `.target` will not be correctly typed to the web component's `HTMLElement` (when using event bindings in Angular). 

Dev-build: `0.6.1-dev.11667512184.13935f80`