### PR TITLE
fix(vue): add correct v-model type

### DIFF
--- a/packages/vue-output-target/__tests__/generate-vue-components.spec.ts
+++ b/packages/vue-output-target/__tests__/generate-vue-components.spec.ts
@@ -79,7 +79,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent>
     });
 
     expect(output).toEqual(`
-export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent>('my-component', undefined, [
+export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent, Components.MyComponent.value>('my-component', undefined, [
   'value',
   'ionChange'
 ],
@@ -139,7 +139,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent>
     });
 
     expect(output).toEqual(`
-export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent>('my-component', undefined, [
+export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent, Components.MyComponent.value>('my-component', undefined, [
   'value',
   'ionChange'
 ],

--- a/packages/vue-output-target/__tests__/generate-vue-components.spec.ts
+++ b/packages/vue-output-target/__tests__/generate-vue-components.spec.ts
@@ -79,7 +79,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent>
     });
 
     expect(output).toEqual(`
-export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent, Components.MyComponent.value>('my-component', undefined, [
+export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent, Components.MyComponent["value"]>('my-component', undefined, [
   'value',
   'ionChange'
 ],
@@ -139,7 +139,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent,
     });
 
     expect(output).toEqual(`
-export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent, Components.MyComponent.value>('my-component', undefined, [
+export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent, Components.MyComponent["value"]>('my-component', undefined, [
   'value',
   'ionChange'
 ],

--- a/packages/vue-output-target/src/generate-vue-component.ts
+++ b/packages/vue-output-target/src/generate-vue-component.ts
@@ -25,7 +25,7 @@ export const createComponentDefinition =
     const componentType = `${importTypes}.${tagNameAsPascal}`;
     const findModel =
       componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
-    const modelType = findModel !== undefined ? `, ${componentType}.${findModel.targetAttr}` : '';
+    const modelType = findModel !== undefined ? `, ${componentType}["${findModel.targetAttr}"]` : '';
 
     let templateString = `
 export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${componentType}${modelType}>('${cmpMeta.tagName}', ${importAs}`;

--- a/packages/vue-output-target/src/generate-vue-component.ts
+++ b/packages/vue-output-target/src/generate-vue-component.ts
@@ -23,12 +23,12 @@ export const createComponentDefinition =
     }
 
     const componentType = `${importTypes}.${tagNameAsPascal}`;
-    const findModel = componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
+    const findModel =
+      componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
     const modelType = findModel !== undefined ? `, ${componentType}.${findModel.targetAttr}` : '';
 
     let templateString = `
 export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${componentType}${modelType}>('${cmpMeta.tagName}', ${importAs}`;
-
 
     if (props.length > 0) {
       templateString += `, [

--- a/packages/vue-output-target/src/generate-vue-component.ts
+++ b/packages/vue-output-target/src/generate-vue-component.ts
@@ -36,7 +36,7 @@ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${componentType}
 ]`;
       /**
        * If there are no props,
-       * but but v-model is still used,
+       * but v-model is still used,
        * make sure we pass in an empty array
        * otherwise all of the defineContainer properties
        * will be off by one space.

--- a/packages/vue-output-target/src/generate-vue-component.ts
+++ b/packages/vue-output-target/src/generate-vue-component.ts
@@ -22,11 +22,13 @@ export const createComponentDefinition =
       props = [...props, ...cmpMeta.events.map((event) => `'${event.name}'`)];
     }
 
-    let templateString = `
-export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${importTypes}.${tagNameAsPascal}>('${cmpMeta.tagName}', ${importAs}`;
+    const componentType = `${importTypes}.${tagNameAsPascal}`;
+    const findModel = componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
+    const modelType = findModel !== undefined ? `, ${componentType}.${findModel.targetAttr}` : '';
 
-    const findModel =
-      componentModelConfig && componentModelConfig.find((config) => config.elements.includes(cmpMeta.tagName));
+    let templateString = `
+export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${componentType}${modelType}>('${cmpMeta.tagName}', ${importAs}`;
+
 
     if (props.length > 0) {
       templateString += `, [
@@ -34,7 +36,7 @@ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${importTypes}.$
 ]`;
       /**
        * If there are no props,
-       * but but v-model is stil used,
+       * but but v-model is still used,
        * make sure we pass in an empty array
        * otherwise all of the defineContainer properties
        * will be off by one space.

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -54,7 +54,7 @@ const getElementClasses = (
  * @prop externalModelUpdateEvent - The external event to fire from your Vue component when modelUpdateEvent fires. This is used for ensuring that v-model references have been
  * correctly updated when a user's event callback fires.
  */
-export const defineContainer = <Props, VModelType = string | number | boolean>(
+export const defineContainer = <Props, VModelType = any>(
   name: string,
   defineCustomElement: any,
   componentProps: string[] = [],

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -54,7 +54,7 @@ const getElementClasses = (
  * @prop externalModelUpdateEvent - The external event to fire from your Vue component when modelUpdateEvent fires. This is used for ensuring that v-model references have been
  * correctly updated when a user's event callback fires.
  */
-export const defineContainer = <Props, VModelType = any>(
+export const defineContainer = <Props, VModelType = string | number | boolean>(
   name: string,
   defineCustomElement: any,
   componentProps: string[] = [],


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: see https://github.com/ionic-team/ionic-framework/issues/27057

The Vue framework wrappers assume the prop for components with v-model support have a type of `string | number | boolean`: https://github.com/ionic-team/stencil-ds-output-targets/blob/caa473216ccdc13ee988831ebe65ec62bbbcbfaa/packages/vue-output-target/vue-component-lib/utils.ts#L57

This is not always true as the `ion-select` value prop has a type of `any | null`: https://github.com/ionic-team/ionic-framework/blob/4b822eac5df9e5caa09d56cd1603486996d41429/core/src/components/select/select.tsx#L112

This is causing a TypeScript error when developers pass an object to the `value` prop on `ion-select` since it is not of the allowed type: https://github.com/ionic-team/ionic-framework/issues/27057

This type can be configured when generating Vue wrappers, but it looks like this functionality was never implemented.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates `generate-vue-component.ts` to customize `VModelType` using the `targetAttr` type for components that support v-model.

Example: `ion-select` would get something like the following:

```js
/*@__PURE__*/ defineContainer<JSX.IonSelect, JSX.IonSelect["value"]>(
```

Which translates to `VModel = any | null` which is the type of `JSX.IonSelect.value`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I tested this in the repro on the linked issue, and the fix worked correctly: `6.7.2-dev.11680184869.1b4a0db8`
