### PR TITLE
feat(angular): omit output related imports for components with no event

### DIFF
--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -68,23 +68,27 @@ export function generateProxies(
   const dtsFilePath = path.join(rootDir, distTypesDir, GENERATED_DTS);
   const componentsTypeFile = relativeImport(outputTarget.directivesProxyFile, dtsFilePath, '.d.ts');
   const includeSingleComponentAngularModules = outputTarget.includeSingleComponentAngularModules ?? false;
+  const includeOutputImports = components.some((component) => component.events.some((event) => !event.internal));
 
   /**
    * The collection of named imports from @angular/core.
    */
-  const angularCoreImports = [
-    'ChangeDetectionStrategy',
-    'ChangeDetectorRef',
-    'Component',
-    'ElementRef',
-    'EventEmitter',
-    'NgZone',
-  ];
+  const angularCoreImports = ['ChangeDetectionStrategy', 'ChangeDetectorRef', 'Component', 'ElementRef'];
+
+  if (includeOutputImports) {
+    angularCoreImports.push('EventEmitter');
+  }
+
+  angularCoreImports.push('NgZone');
 
   /**
    * The collection of named imports from the angular-component-lib/utils.
    */
-  const componentLibImports = ['ProxyCmp', 'proxyOutputs'];
+  const componentLibImports = ['ProxyCmp'];
+
+  if (includeOutputImports) {
+    componentLibImports.push('proxyOutputs');
+  }
 
   if (includeSingleComponentAngularModules) {
     angularCoreImports.push('NgModule');


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally for affected output targets
- [X] Tests (`npm test`) were run locally and passed
- [X] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

It will always add `EventEmitter` and `proxyOutputs` imports event if there are no components with event.

Issue URL: Resolves #331

## What is the new behavior?

Include import `EventEmitter` and `proxyOutputs` only if there is at least one component with event.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
