### PR TITLE
chore(repo): use new output nomenclature for dev builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -36,7 +36,7 @@ jobs:
           HUSKY_SKIP_HOOKS=1 lerna publish $(echo "${{ env.CURRENT_VERSION }}")-dev.$(echo "${{ env.TIMESTAMP }}").$(echo "${{ env.HASH }}") --no-verify-access --yes --force-publish='*' --dist-tag dev --no-git-tag-version --no-push --exact
         shell: bash
       - id: dev-build
-        run: echo "::set-output name=version::$(echo "${{ env.CURRENT_VERSION }}")-dev.$(echo "${{ env.TIMESTAMP }}").$(echo "${{ env.HASH }}")"
+        run: echo "version=$(echo "${{ env.CURRENT_VERSION }}")-dev.$(echo "${{ env.TIMESTAMP }}").$(echo "${{ env.HASH }}")" >> $GITHUB_OUTPUT
   get-build:
     name: Get your dev build!
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our tech debt burndown job uses the `set-output` syntax. `set-output` was deprecated on 2022.10.11, in
favor of a new syntax - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. starting 2023.05.31, `set-output` is intended to be disabled.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates all workflows using the "old" output nomenclature to
use the newer variant.  applying this commit will allow the tech debt burndown to continue to function as
expected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
⚠️ TODO

## Other information

Waiting for us to discuss the dev build issues (see slack for this repo) before marking this ready to review
