### PR TITLE
chore(repo): add stale settings to ionitron config

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -26,7 +26,6 @@ comment:
 
 
         If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was not enough for our team to reproduce the issue.
-
   dryRun: false
 
 closeAndLock:
@@ -63,13 +62,25 @@ noReply:
   lock: true
   dryRun: false
 
-noReproduction:
+stale:
   days: 14
   maxIssuesPerRun: 100
-  label: "ionitron: needs reproduction"
-  responseLabel: triage
+  exemptLabels:
+    - dependencies
+    - documentation
+    - help wanted
+    - internal
+    - 'needs: reply' # allow the `noReply` configuration above to handle these issues
+    - 'package: angular'
+    - 'package: react'
+    - 'package: vue'
+    - triage
+    - 'type: bug'
+    - 'type: feature'
+  exemptAssigned: true
   exemptProjects: true
   exemptMilestones: true
+  label: 'ionitron: stale issue'
   message: >
     Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
     an issue with the latest version of the output targets, please create a new issue and ensure the


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Repo config changes

## What is the current behavior?

Ionitron does not close "stale" issues

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the ionitron configuration for the repo by:
1. removing `noReproduction`, as there's no code in ionitron to handle
   this block
2. adding a `stale` configuration, to clore issues that are inactive
   (14 days) and are not labeled

the labels here were chosen to ensure:
- currently labeled issues do not get immediately closed (they reflect
  the current state of the repo)
- labels we plan on continuing to use in the long term are added (e.g.
  `package: angular`)
- there are no conflicts with pre-existing rules in the ionitron config

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I have pre-emptively added "triage" to some ~22 issues that were unlabeled to prevent them from being accidentally closed (before the team takes an actual look)
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
