### PR TITLE
fix(vue): Fix typechecking in library code for the Vue output target.

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+// It's easier and safer for Volar to disable typechecking and let the return type inference do its job.
 import { VNode, defineComponent, getCurrentInstance, h, inject, ref, Ref } from 'vue';
 
 export interface InputProps<T> {
@@ -72,7 +74,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     defineCustomElement();
   }
 
-  const Container = defineComponent<Props & InputProps<VModelType>>((props: any, { attrs, slots, emit }) => {
+  const Container = defineComponent<Props & InputProps<VModelType>>((props, { attrs, slots, emit }) => {
     let modelPropValue = props[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
@@ -184,19 +186,21 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     };
   });
 
-  Container.name = name;
+  if (typeof Container !== 'function') {
+    Container.name = name;
 
-  Container.props = {
-    [ROUTER_LINK_VALUE]: DEFAULT_EMPTY_PROP,
-  };
+    Container.props = {
+      [ROUTER_LINK_VALUE]: DEFAULT_EMPTY_PROP,
+    };
 
-  componentProps.forEach((componentProp) => {
-    Container.props[componentProp] = DEFAULT_EMPTY_PROP;
-  });
+    componentProps.forEach((componentProp) => {
+      Container.props[componentProp] = DEFAULT_EMPTY_PROP;
+    });
 
-  if (modelProp) {
-    Container.props[MODEL_VALUE] = DEFAULT_EMPTY_PROP;
-    Container.emits = [UPDATE_VALUE_EVENT, externalModelUpdateEvent];
+    if (modelProp) {
+      Container.props[MODEL_VALUE] = DEFAULT_EMPTY_PROP;
+      Container.emits = [UPDATE_VALUE_EVENT, externalModelUpdateEvent];
+    }
   }
 
   return Container;


### PR DESCRIPTION
Vue 3.3 added support for generic component types and changed the return type of `defineComponent` significantly. It's now always a function.

Since the vue-component-lib is simply moved into the user's library without preprocessing, it has to support the full range of Vue versions supported by Stencil.

Properly fixing the Vue runtime code (Container.name = 'whatever') conditionally *without breaking the type inference* is hard.

It's much easier for us and safer for Volar for us to disable typechecking and let the type inference do its job.

By removing `props: any`, Volar now infers props via inferred return types and we have TypeScript support for Vue.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

1. Vue 3.3 doesn't compile
2. Volar doesn't work

Issue URL: #340

## What is the new behavior?

Types work in Volar!

<img width="422" alt="Screenshot 2023-05-16 at 9 11 59 PM" src="https://github.com/ionic-team/stencil-ds-output-targets/assets/2801156/b3e7a55a-fd32-44e6-9c00-604f467e9479">

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
