### PR TITLE
chore(peerDeps): bumping the @stencil/core required peerDep for v4 launch

### DIFF
--- a/packages/angular-output-target/package-lock.json
+++ b/packages/angular-output-target/package-lock.json
@@ -13,7 +13,7 @@
         "@angular/forms": "8.2.14"
       },
       "peerDependencies": {
-        "@stencil/core": "^2.9.0 || ^3.0.0"
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "node_modules/@angular/common": {

--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -42,7 +42,7 @@
     "@angular/forms": "8.2.14"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.9.0 || ^3.0.0"
+    "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/react-output-target/package-lock.json
+++ b/packages/react-output-target/package-lock.json
@@ -16,7 +16,7 @@
         "react-testing-library": "^7.0.0"
       },
       "peerDependencies": {
-        "@stencil/core": "^2.9.0 || ^3.0.0"
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/packages/react-output-target/package.json
+++ b/packages/react-output-target/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/ionic-team/stencil-ds-output-targets/issues"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.9.0 || ^3.0.0"
+    "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.7.0",

--- a/packages/vue-output-target/package-lock.json
+++ b/packages/vue-output-target/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "license": "MIT",
       "peerDependencies": {
-        "@stencil/core": "^2.9.0 || ^3.0.0"
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "node_modules/@stencil/core": {

--- a/packages/vue-output-target/package.json
+++ b/packages/vue-output-target/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/ionic-team/stencil-ds-output-targets/issues"
   },
   "peerDependencies": {
-    "@stencil/core": "^2.9.0 || ^3.0.0"
+    "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
* Both the >= 4.0.0-beta.0 >= 4.0.0 are needed, due to the way that npm interprets pre-release versions
* We will remove/clean-up the pre-release acceptance after v4 of Stencil is released

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue URL: [STENCIL-810](https://ionic-cloud.atlassian.net/browse/STENCIL-810)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Supports peerDependencies for Stencil correctly

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

[STENCIL-810]: https://ionic-cloud.atlassian.net/browse/STENCIL-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ