### PR TITLE
fix(react): component wrappers work with onDoubleClick

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
     "packages/example-project/component-library-vue",
     "packages/example-project/component-library-svelte"
   ],
-  "version": "0.5.0",
+  "version": "independent",
   "command": {
     "publish": {
       "ignoreChanges": ["packages/example-project/*", "**/package.json", "**/package-lock.json"]

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
     "packages/example-project/component-library-vue",
     "packages/example-project/component-library-svelte"
   ],
-  "version": "independent",
+  "version": "0.5.0",
   "command": {
     "publish": {
       "ignoreChanges": ["packages/example-project/*", "**/package.json", "**/package-lock.json"]

--- a/packages/react-output-target/react-component-lib/utils/attachProps.ts
+++ b/packages/react-output-target/react-component-lib/utils/attachProps.ts
@@ -63,6 +63,17 @@ export const getClassName = (classList: DOMTokenList, newProps: any, oldProps: a
 };
 
 /**
+ * Transforms a React event name to a browser event name.
+ */
+export const transformReactEventName = (eventNameSuffix: string) => {
+  switch (eventNameSuffix) {
+    case 'doubleclick':
+      return 'dblclick';
+  }
+  return eventNameSuffix;
+}
+
+/**
  * Checks if an event is supported in the current execution environment.
  * @license Modernizr 3.0.0pre (Custom Build) | MIT
  */
@@ -70,7 +81,7 @@ export const isCoveredByReact = (eventNameSuffix: string) => {
   if (typeof document === 'undefined') {
     return true;
   } else {
-    const eventName = 'on' + eventNameSuffix;
+    const eventName = 'on' + transformReactEventName(eventNameSuffix);
     let isSupported = eventName in document;
 
     if (!isSupported) {

--- a/packages/react-output-target/react-component-lib/utils/attachProps.ts
+++ b/packages/react-output-target/react-component-lib/utils/attachProps.ts
@@ -71,7 +71,7 @@ export const transformReactEventName = (eventNameSuffix: string) => {
       return 'dblclick';
   }
   return eventNameSuffix;
-}
+};
 
 /**
  * Checks if an event is supported in the current execution environment.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Generated React component wrappers will not fire the `dblclick` event when `onDoubleClick` is bound to the wrapper.

e.g.:
```tsx
<MyComponent onDoubleClick={() => alert('Hello world')}>Click me</MyComponent>
```

Issue URL: Relates to: https://github.com/ionic-team/ionic-framework/issues/21320

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Transforms `doubleclick` naming syntax from React to the browser event `dblclick`
- Creates a utility that can be consumed in a developers projects where they manually generate wrappers (e.g. Ionic Framework generates manual wrappers for routing elements)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `0.5.1-dev.11685564559.1b0b6e89`

Ionic Framework dev-build: `7.0.11-dev.11685565959.10c33d71`