### PR TITLE
chore(npm): manually bumping the package versions

### DIFF
--- a/packages/angular-output-target/package-lock.json
+++ b/packages/angular-output-target/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/angular-output-target",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/angular-output-target",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@angular/core": "8.2.14",

--- a/packages/angular-output-target/package.json
+++ b/packages/angular-output-target/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/angular-output-target",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Angular output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/react-output-target/package-lock.json
+++ b/packages/react-output-target/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/react-output-target",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/react-output-target",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^16.7.0",

--- a/packages/react-output-target/package.json
+++ b/packages/react-output-target/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/react-output-target",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "React output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/vue-output-target/package-lock.json
+++ b/packages/vue-output-target/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/vue-output-target",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"

--- a/packages/vue-output-target/package.json
+++ b/packages/vue-output-target/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Vue output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
PRs like this are necessary until we have a bot committing back onto main after a successful production release.