### PR TITLE
fix(angular-output-target): rewrite nested generics for custom events

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
     "packages/example-project/component-library-vue",
     "packages/example-project/component-library-svelte"
   ],
-  "version": "independent",
+  "version": "0.7.1",
   "command": {
     "publish": {
       "ignoreChanges": ["packages/example-project/*", "**/package.json", "**/package-lock.json"]

--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
     "packages/example-project/component-library-vue",
     "packages/example-project/component-library-svelte"
   ],
-  "version": "0.7.1",
+  "version": "independent",
   "command": {
     "publish": {
       "ignoreChanges": ["packages/example-project/*", "**/package.json", "**/package-lock.json"]

--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -313,6 +313,57 @@ export declare interface MyComponent extends Components.MyComponent {
 }`
       );
     });
+
+    it('rewrites complex nested generic types within custom events', () => {
+      // Issue: https://github.com/ionic-team/stencil-ds-output-targets/issues/369
+      const definition = createComponentTypeDefinition(
+        'component',
+        'MyComponent',
+        [
+          {
+            name: 'myChange',
+            method: 'myChange',
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            docs: {
+              tags: [],
+              text: '',
+            },
+            complexType: {
+              original: 'MyEvent<Currency>',
+              resolved: 'MyEvent<Currency>',
+              references: {
+                MyEvent: {
+                  location: 'import',
+                  path: '../../types/MyEvent',
+                  // Stencil v4.0.3+ only
+                  id: 'src/types/MyEvent.ts::MyEvent',
+                } as any,
+                Currency: {
+                  location: 'import',
+                  path: '../../types/Currency',
+                  // Stencil v4.0.3+ only
+                  id: 'src/types/Currency.ts::Currency',
+                } as any,
+              },
+            },
+            internal: false,
+          },
+        ],
+        '@ionic/core'
+      );
+
+      expect(definition).toEqual(
+        `import type { MyEvent as IMyComponentMyEvent } from '@ionic/core';
+import type { Currency as IMyComponentCurrency } from '@ionic/core';
+
+export declare interface MyComponent extends Components.MyComponent {
+
+  myChange: EventEmitter<CustomEvent<IMyComponentIMyComponentMyEvent<IMyComponentCurrency>>>;
+}`
+      );
+    });
   });
 
   describe('custom elements output', () => {

--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -360,7 +360,7 @@ import type { Currency as IMyComponentCurrency } from '@ionic/core';
 
 export declare interface MyComponent extends Components.MyComponent {
 
-  myChange: EventEmitter<CustomEvent<IMyComponentIMyComponentMyEvent<IMyComponentCurrency>>>;
+  myChange: EventEmitter<CustomEvent<IMyComponentMyEvent<IMyComponentCurrency>>>;
 }`
       );
     });

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -95,6 +95,7 @@ export class ${tagNameAsPascal} {
  * @returns The sanitized event type as a string.
  */
 const formatOutputType = (componentClassName: string, event: ComponentCompilerEvent) => {
+  const prefix = `I${componentClassName}`;
   /**
    * The original attribute contains the original type defined by the devs.
    * This regexp normalizes the reference, by removing linebreaks,
@@ -104,7 +105,10 @@ const formatOutputType = (componentClassName: string, event: ComponentCompilerEv
     .filter(([_, refObject]) => refObject.location === 'local' || refObject.location === 'import')
     .reduce(
       (type, [src, dst]) => {
-        const renamedType = `I${componentClassName}${type}`;
+        let renamedType = type;
+        if (!type.startsWith(prefix)) {
+          renamedType = `I${componentClassName}${type}`;
+        }
         return (
           renamedType
             .replace(new RegExp(`^${src}$`, 'g'), `${dst}`)

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -109,7 +109,17 @@ const formatOutputType = (componentClassName: string, event: ComponentCompilerEv
           renamedType
             .replace(new RegExp(`^${src}$`, 'g'), `${dst}`)
             // Capture all instances of the `src` field surrounded by non-word characters on each side and join them.
-            .replace(new RegExp(`([^\\w])${src}([^\\w])`, 'g'), (v, p1, p2) => [p1, dst, p2].join(''))
+            .replace(new RegExp(`([^\\w])${src}([^\\w])`, 'g'), (v, p1, p2) => {
+              if (dst?.location === 'import') {
+                /**
+                 * Replaces a complex type reference within a generic type.
+                 * For example, remapping a type like `EventEmitter<CustomEvent<MyEvent<T>>>` to
+                 * `EventEmitter<CustomEvent<IMyComponentMyEvent<IMyComponentT>>`.
+                 */
+                return [p1, `I${componentClassName}${v.substring(1, v.length - 1)}`, p2].join('');
+              }
+              return [p1, dst, p2].join('');
+            })
         );
       },
       event.complexType.original

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -118,7 +118,7 @@ const formatOutputType = (componentClassName: string, event: ComponentCompilerEv
                 /**
                  * Replaces a complex type reference within a generic type.
                  * For example, remapping a type like `EventEmitter<CustomEvent<MyEvent<T>>>` to
-                 * `EventEmitter<CustomEvent<IMyComponentMyEvent<IMyComponentT>>`.
+                 * `EventEmitter<CustomEvent<IMyComponentMyEvent<IMyComponentT>>>`.
                  */
                 return [p1, `I${componentClassName}${v.substring(1, v.length - 1)}`, p2].join('');
               }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: Resolves #369

Nested generic types in custom events do not get rewritten correctly within the angular output target. Currently it will output something similar to:

```ts
CustomEvent<IMyComponentIMyComponentMyEvent<[object Object]>>
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Angular output target replaces nested generic types within custom events

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `@stencil/angular-output-target@0.7.2-dev.11691686917.1045ccb9`
