### PR TITLE
fix(angular-output-target): multiple targets do not overwrite each other

### DIFF
--- a/packages/angular-output-target/src/plugin.ts
+++ b/packages/angular-output-target/src/plugin.ts
@@ -4,22 +4,24 @@ import { angularDirectiveProxyOutput } from './output-angular';
 import type { OutputTargetAngular } from './types';
 import path from 'path';
 
-let validatedOutputTarget: OutputTargetAngular;
+export const angularOutputTarget = (outputTarget: OutputTargetAngular): OutputTargetCustom => {
+  let validatedOutputTarget: OutputTargetAngular;
 
-export const angularOutputTarget = (outputTarget: OutputTargetAngular): OutputTargetCustom => ({
-  type: 'custom',
-  name: 'angular-library',
-  validate(config) {
-    validatedOutputTarget = normalizeOutputTarget(config, outputTarget);
-  },
-  async generator(config, compilerCtx, buildCtx) {
-    const timespan = buildCtx.createTimeSpan(`generate angular proxies started`, true);
+  return {
+    type: 'custom',
+    name: 'angular-library',
+    validate(config) {
+      validatedOutputTarget = normalizeOutputTarget(config, outputTarget);
+    },
+    async generator(config, compilerCtx, buildCtx) {
+      const timespan = buildCtx.createTimeSpan(`generate angular proxies started`, true);
 
-    await angularDirectiveProxyOutput(compilerCtx, validatedOutputTarget, buildCtx.components, config);
+      await angularDirectiveProxyOutput(compilerCtx, validatedOutputTarget, buildCtx.components, config);
 
-    timespan.finish(`generate angular proxies finished`);
-  },
-});
+      timespan.finish(`generate angular proxies finished`);
+    },
+  };
+};
 
 export function normalizeOutputTarget(config: Config, outputTarget: OutputTargetAngular) {
   const results: OutputTargetAngular = {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

When referencing multiple instances of the Angular output target in your Stencil project, it will only generate the last instance of the output target. 

Due to invalid global state caching, the last executed validate step will be used for all generate steps of the output target. This is not desired and prevents using multiple instances of an output target.

Issue URL: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Block-scope cache the validated output target across the validate and generator steps - does not cache across output target.
- Developers can use multiple instances of the same output target in their projects.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
