### PR TITLE
feat(vue): adding missing types for custom components

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 // It's easier and safer for Volar to disable typechecking and let the return type inference do its job.
-import { VNode, defineComponent, getCurrentInstance, h, inject, ref, Ref } from 'vue';
+import { VNode, defineComponent, getCurrentInstance, h, inject, ref, Ref, StyleValue } from 'vue';
+
+export interface ComponentExtensionType {
+  style?: StyleValue
+  class?: any
+  slot?: string
+}
 
 export interface InputProps<T> {
   modelValue?: T;
@@ -74,7 +80,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     defineCustomElement();
   }
 
-  const Container = defineComponent<Props & InputProps<VModelType>>((props, { attrs, slots, emit }) => {
+  const Container = defineComponent<Props & ComponentExtensionType & InputProps<VModelType>>((props, { attrs, slots, emit }) => {
     let modelPropValue = props[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -6,6 +6,7 @@ export interface ComponentExtensionType {
   style?: StyleValue
   class?: any
   slot?: string
+  [key: string]: any
 }
 
 export interface InputProps<T> {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Error when writing `style`, `class`, `slot` in a custom component after packaging it as `vue`.

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: ionic-team/stencil#363 and [https://github.com/ionic-team/stencil-ds-output-targets/issues/383](https://github.com/ionic-team/stencil-ds-output-targets/issues/383)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now there is no ts type error when writing `style`, `class`, `slot` for custom components again!

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
