### PR TITLE
feat(vue): add missing event emitter

### DIFF
--- a/packages/vue-output-target/src/generate-vue-component.ts
+++ b/packages/vue-output-target/src/generate-vue-component.ts
@@ -13,6 +13,7 @@ export const createComponentDefinition =
     const importAs = includeCustomElement ? 'define' + tagNameAsPascal : 'undefined';
 
     let props: string[] = [];
+    let emits: string[] = [];
 
     if (Array.isArray(cmpMeta.properties) && cmpMeta.properties.length > 0) {
       props = cmpMeta.properties.map((prop) => `'${prop.name}'`);
@@ -20,6 +21,7 @@ export const createComponentDefinition =
 
     if (Array.isArray(cmpMeta.events) && cmpMeta.events.length > 0) {
       props = [...props, ...cmpMeta.events.map((event) => `'${event.name}'`)];
+      emits = cmpMeta.events.map((event) => `'${event.name}'`);
     }
 
     const componentType = `${importTypes}.${tagNameAsPascal}`;
@@ -36,6 +38,25 @@ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${componentType}
 ]`;
       /**
        * If there are no props,
+       * but v-model is still used,
+       * make sure we pass in an empty array
+       * otherwise all of the defineContainer properties
+       * will be off by one space.
+       * Note: If you are using v-model then
+       * the props array should never be empty
+       * as there must be a prop for v-model to update,
+       * but this check is there so builds do not crash.
+       */
+    } else if (emits.length > 0) {
+      templateString += `, []`;
+    }
+
+    if (emits.length > 0) {
+      templateString += `, [
+  ${emits.length > 0 ? emits.join(',\n  ') : ''}
+]`;
+      /**
+       * If there are no Emits,
        * but v-model is still used,
        * make sure we pass in an empty array
        * otherwise all of the defineContainer properties

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -49,6 +49,9 @@ const getElementClasses = (
  * @prop componentProps - An array of properties on the
  * component. These usually match up with the @Prop definitions
  * in each component's TSX file.
+ * @prop emitProps - An array of for event listener on the Component.
+ * these usually match up with the @Event definitions
+ * in each compont's TSX file.
  * @prop customElement - An option custom element instance to pass
  * to customElements.define. Only set if `includeImportCustomElements: true` in your config.
  * @prop modelProp - The prop that v-model binds to (i.e. value)
@@ -60,6 +63,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
   name: string,
   defineCustomElement: any,
   componentProps: string[] = [],
+  emitProps: string[] = [],
   modelProp?: string,
   modelUpdateEvent?: string,
   externalModelUpdateEvent?: string
@@ -74,30 +78,43 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     defineCustomElement();
   }
 
-  const Container = defineComponent<Props & InputProps<VModelType>>((props, { attrs, slots, emit }) => {
+  const Container = defineComponent<Props & InputProps<VModelType>>((props: any, { attrs, slots, emit }) => {
     let modelPropValue = props[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
+    const addBeforeMount = !!modelUpdateEvent || !!emitProps.length;
     const onVnodeBeforeMount = (vnode: VNode) => {
       // Add a listener to tell Vue to update the v-model
       if (vnode.el) {
-        const eventsNames = Array.isArray(modelUpdateEvent) ? modelUpdateEvent : [modelUpdateEvent];
-        eventsNames.forEach((eventName: string) => {
-          vnode.el!.addEventListener(eventName.toLowerCase(), (e: Event) => {
-            modelPropValue = (e?.target as any)[modelProp];
-            emit(UPDATE_VALUE_EVENT, modelPropValue);
+        if (modelUpdateEvent) {
+          const eventsNames = Array.isArray(modelUpdateEvent) ? modelUpdateEvent : [modelUpdateEvent];
+          eventsNames.forEach((eventName: string) => {
+            vnode.el!.addEventListener(eventName.toLowerCase(), (e: any) => {
+              modelPropValue = e.detail !== undefined ? e.detail : (e?.target as any)[modelProp];
+              emit(UPDATE_VALUE_EVENT, modelPropValue);
 
-            /**
-             * We need to emit the change event here
-             * rather than on the web component to ensure
-             * that any v-model bindings have been updated.
-             * Otherwise, the developer will listen on the
-             * native web component, but the v-model will
-             * not have been updated yet.
-             */
-            if (externalModelUpdateEvent) {
-              emit(externalModelUpdateEvent, e);
-            }
+              /**
+               * We need to emit the change event here
+               * rather than on the web component to ensure
+               * that any v-model bindings have been updated.
+               * Otherwise, the developer will listen on the
+               * native web component, but the v-model will
+               * not have been updated yet.
+               */
+              if (externalModelUpdateEvent) {
+                emit(externalModelUpdateEvent, e);
+              }
+            });
+          });
+        }
+
+        /**
+         * we register the event emmiter for @Event definitions
+         * so we can use @event
+         */
+        emitProps.forEach((eventName: string) => {
+          vnode.el!.addEventListener(eventName, (e: Event) => {
+            emit(eventName, e);
           });
         });
       }
@@ -146,7 +163,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
         ref: containerRef,
         class: getElementClasses(containerRef, classes),
         onClick: handleClick,
-        onVnodeBeforeMount: modelUpdateEvent ? onVnodeBeforeMount : undefined,
+        onVnodeBeforeMount: addBeforeMount ? onVnodeBeforeMount : undefined,
       };
 
       /**
@@ -186,19 +203,35 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     };
   });
 
-  if (typeof Container !== 'function') {
-    Container.name = name;
+  Container.displayName = name;
 
-    Container.props = {
-      [ROUTER_LINK_VALUE]: DEFAULT_EMPTY_PROP,
-    };
+  Container.props = {
+    [ROUTER_LINK_VALUE]: DEFAULT_EMPTY_PROP,
+  };
 
-    componentProps.forEach((componentProp) => {
-      Container.props[componentProp] = DEFAULT_EMPTY_PROP;
-    });
+  componentProps.forEach((componentProp) => {
+    Container.props[componentProp] = DEFAULT_EMPTY_PROP;
+  });
 
-    if (modelProp) {
-      Container.props[MODEL_VALUE] = DEFAULT_EMPTY_PROP;
+  /**
+   * Add emit props to the component.
+   * This is necessary for Vue to know
+   * which events to listen to.
+   * @see https://v3.vuejs.org/guide/component-custom-events.html#event-names
+   */
+  emitProps.forEach((emitProp) => {
+    if (Array.isArray(Container.emits)) {
+      Container.emits.push(emitProp);
+    } else {
+      Container.emits = [emitProp];
+    }
+  });
+
+  if (modelProp) {
+    Container.props[MODEL_VALUE] = DEFAULT_EMPTY_PROP;
+    if (Array.isArray(Container.emits)) {
+      Container.emits.push(UPDATE_VALUE_EVENT, externalModelUpdateEvent);
+    } else {
       Container.emits = [UPDATE_VALUE_EVENT, externalModelUpdateEvent];
     }
   }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

* custom events will never emit in Vue
```ts
// will never fire!
function checkedChange(e) {
  console.log("checked!") 
}

<IxToggle @checkedChange="checkedChange" />
```

Issue URL: https://github.com/ionic-team/stencil-ds-output-targets/issues/382

## What is the new behavior?

* Introduce the emitProps property to the defineContainer (an array for configuring event listeners on the Component, similar to the usage of @Event() decorator in a web component).
* Revise the componentProps array and reposition the @Events() decorator under the emitProps section.
```ts
// will fire now
function checkedChange(e) {
  console.log("checked!")
}

<IxToggle @checkedChange="checkedChange" />
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

