### PR TITLE
fix(vue): ensure v-model is updated before event callback

### DIFF
--- a/packages/vue-output-target/README.md
+++ b/packages/vue-output-target/README.md
@@ -72,17 +72,6 @@ export interface ComponentModelConfig {
    * of the `v-model` reference is based off.
    */
   targetAttr: string;
-
-  /**
-   * (optional) The event to emit from the Vue component
-   * wrapper. When listening directly to the `event` emitted
-   * from the Web Component, the `v-model` reference has not
-   * yet had a chance to update. By setting `externalEvent`,
-   * your Web Component can emit `event`, the Vue output target
-   * can update the `v-model` reference, and then emit `externalEvent`,
-   * notifying the end user that `v-model` has changed. Defaults to `event`.
-   */
-  externalEvent?: string;
 }
 ```
 
@@ -94,8 +83,7 @@ vueOutputTarget({
   componentModels: [
     {
       elements: ['my-input', 'my-textarea'],
-      event: 'v-on-change',
-      externalEvent: 'on-change',
+      event: 'on-change',
       targetAttr: 'value'
     }
   ]

--- a/packages/vue-output-target/__tests__/generate-vue-components.spec.ts
+++ b/packages/vue-output-target/__tests__/generate-vue-components.spec.ts
@@ -30,8 +30,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent>
     const generateComponentDefinition = createComponentDefinition('Components', [
       {
         elements: ['my-component'],
-        event: 'v-ionChange',
-        externalEvent: 'ionChange',
+        event: 'ionChange',
         targetAttr: 'value',
       },
     ]);
@@ -83,7 +82,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent,
   'value',
   'ionChange'
 ],
-'value', 'v-ionChange', 'ionChange');
+'value', 'ionChange');
 `);
   });
 
@@ -91,8 +90,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent,
     const generateComponentDefinition = createComponentDefinition('Components', [
       {
         elements: ['my-component'],
-        event: 'v-ionChange',
-        externalEvent: 'ionChange',
+        event: 'ionChange',
         targetAttr: 'value',
       },
     ]);
@@ -143,7 +141,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<Components.MyComponent,
   'value',
   'ionChange'
 ],
-'value', 'v-ionChange', 'ionChange');
+'value', 'ionChange');
 `);
   });
 

--- a/packages/vue-output-target/src/generate-vue-component.ts
+++ b/packages/vue-output-target/src/generate-vue-component.ts
@@ -65,10 +65,6 @@ export const ${tagNameAsPascal} = /*@__PURE__*/ defineContainer<${componentType}
 
       templateString += `,\n`;
       templateString += `'${targetProp}', '${findModel.event}'`;
-
-      if (findModel.externalEvent) {
-        templateString += `, '${findModel.externalEvent}'`;
-      }
     }
 
     templateString += `);\n`;

--- a/packages/vue-output-target/src/types.ts
+++ b/packages/vue-output-target/src/types.ts
@@ -14,7 +14,6 @@ export interface ComponentModelConfig {
   elements: string | string[];
   event: string;
   targetAttr: string;
-  externalEvent?: string;
 }
 
 export interface PackageJSON {

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -141,7 +141,6 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
         ref: containerRef,
         class: getElementClasses(containerRef, classes),
         onClick: handleClick,
-        onVnodeBeforeMount: modelUpdateEvent ? onVnodeBeforeMount : undefined,
       };
 
       /**

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -181,7 +181,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
        * As a result, we conditionally call withDirectives with v-model components.
        */
       const node = h(name, propsToAdd, slots.default && slots.default());
-      return modelProp === undefined ? node : withDirectives(node, [vModelDirective]);
+      return modelProp === undefined ? node : withDirectives(node, [[vModelDirective]]);
     };
   });
 

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -75,6 +75,17 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     let modelPropValue = props[modelProp];
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
+
+    /**
+     * This directive is responsible for updating any reactive
+     * reference associated with v-model on the component.
+     * This code must be run inside of the "created" callback.
+     * Since the following listener callbacks as well as any potential
+     * event callback defined in the developer's app are set on
+     * the same element, we need to make sure the following callbacks
+     * are set first so they fire first. If the developer's callback fires first
+     * then the reactive reference will not have been updated yet.
+     */
     const vModelDirective = {
       created(el: HTMLElement) {
         const eventsNames = Array.isArray(modelUpdateEvent) ? modelUpdateEvent : [modelUpdateEvent];
@@ -166,6 +177,10 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
         }
       }
 
+      /**
+       * vModelDirective is only needed on components that support v-model.
+       * As a result, we conditionally call withDirectives with v-model components.
+       */
       const node = h(name, propsToAdd, slots.default && slots.default());
       return modelProp === undefined ? node : withDirectives(node, [vModelDirective]);
     };

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -59,7 +59,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
   defineCustomElement: any,
   componentProps: string[] = [],
   modelProp?: string,
-  modelUpdateEvent?: string,
+  modelUpdateEvent?: string
 ) => {
   /**
    * Create a Vue component wrapper around a Web Component.
@@ -84,8 +84,8 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
             emit(UPDATE_VALUE_EVENT, modelPropValue);
           });
         });
-      }
-    }
+      },
+    };
 
     const currentInstance = getCurrentInstance();
     const hasRouter = currentInstance?.appContext?.provides[NAV_MANAGER];

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -87,7 +87,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
      * then the reactive reference will not have been updated yet.
      */
     const vModelDirective = {
-      created(el: HTMLElement) {
+      created: (el: HTMLElement) => {
         const eventsNames = Array.isArray(modelUpdateEvent) ? modelUpdateEvent : [modelUpdateEvent];
         eventsNames.forEach((eventName: string) => {
           el.addEventListener(eventName.toLowerCase(), (e: Event) => {

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -184,7 +184,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
 
     if (modelProp) {
       Container.props[MODEL_VALUE] = DEFAULT_EMPTY_PROP;
-      Container.emits = [UPDATE_VALUE_EVENT, externalModelUpdateEvent];
+      Container.emits = [UPDATE_VALUE_EVENT];
     }
   }
 


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: Part of https://github.com/ionic-team/ionic-framework/issues/27292

[Try a reproduction of this issue](https://play.vuejs.org/#eNqdVk1v2zgQ/SuEsIDkwJYO3ZNrB9lms9gu2m7RBslFh8rS2FYrkVySchIY/u87HOqDkt2iqA+GRM7Xe5x51DH4Q8r40ECwDFY6V6U0TINp5HXKy1oKZdiRoclbLhvDTmyrRM3COOmWwteenYJtb4Ih7V7Kc8G1YaU1fsiqBtja2kVhOPO2Bb9ttBG1S7NmERxmbH3NjilnzJqICuJK7KLwE+agOOHcCxof7L+NeLJBV4mDgiDwxUAtq8wAvjG26sEcFrUooFqnwRAnDdhNTpXQGu6NKot+gwNwM0uD61VPAYZdJV6OYB44RhZ1JuOvWnDkloBgJtrQabB00OwaMmXf02BvjNTLJMkLjm5YWnlQMQeTcFknN2iWqIabsoZFIeqbV/Gr+PekKLXxl2PQ9WKjxJMGhUHSYO6lSXDxAGqhgBegQP1s2ombn3qydZbeZscjOSEpRuNBbsvdhJJc1LKsQP0rTYkHPaImqyrx9A+tGdVAjyXfQ/7twvpX/ewwfVRAlXn4TaZ2YNz23ecP8IzP/SZ2QlO1x/CdzU+ATdjYGp3Zm4YXWLZnR9W+pRMu+e5e3z0b4LoDZQslNsiezuP2B9CHcpFtj8Wu62KjkcN+9HQlzF9VttP3WHs3hGngjm+fKSjSwB/VArYlpwIEx46es/3gRA05GJsXCejx8AGn5dwIJ7jKtO414vGWYQXYDpr9ff/+3V0FNcbvcI1kAAmkKgoKY7dJDFSTG6GiWedjf7qRgEtoaN9oxu0DMsRo8sfWCgVMcWb2pY6HjFNnlLnWGbXG8564YaGHvsC+SIcE98j6vwbUy2eogCoPaa/Vt86r3LKI1ke5ek6cgHXxzopuCx/V72ZujLz15qAs+Rjuy8oVag8R1cxQZ7Pk+ssvQxqXnRXFnZXEdygGgGk7yznDwjoBH34uUW6BcnhiTlopQBR6uovuR7ZpNpsKtJscdvJzD/lRhGRm8r2LkdMV0BM26pe+wzhCguIWp3WT5d8u8NcRO3hTAHimcXAQ+ltkPR2lKJJKSG0RQF3iLPo8JAn7k8wxE7BH2LDez3YIF4ZllYKseGnDFu3cYPc4ftqB0jH2fhRmUi7ao2HrtTdSI1QTT2fiO8+98T0bsgrnhG7Kj4irG4nQXe6E6eqqTXXFHvfArT4PR4ndti1RjfGKP8fc+z0B9gMUzAjWyALvUbJtb2j7vYCXC88h7hwSTy8w8gNHuzewFQreC7wM7RfEwa4tnWxNW5H2YqgutO+4CyOMQAaXmvmMlAhiJ9ssc+pHlLa8z9yIT7rYtkgUOsxLCth93IyjX+7r12wQA5K8s6Fr1/fj0z5e4GzuxHA5heVPET4Hp/8BxkJXEg==)

(Type into the input and you can see that the logged value is always outdated in the console)

------

We currently implement the following solution for `v-model` support:

1. We add an event listener for the `v-model` event defined by [event](https://github.com/ionic-team/stencil-ds-output-targets/blob/1c8f4d475481c01937c970c09dce8586fa4bb179/packages/vue-output-target/src/types.ts#L15): https://github.com/ionic-team/stencil-ds-output-targets/blob/1c8f4d475481c01937c970c09dce8586fa4bb179/packages/vue-output-target/vue-component-lib/utils.ts#L86
2. When the callback fires, we emit `update:modelValue` [which tells Vue to update the value of any reactive reference](https://vuejs.org/guide/components/v-model.html) set using `v-model`: https://github.com/ionic-team/stencil-ds-output-targets/blob/1c8f4d475481c01937c970c09dce8586fa4bb179/packages/vue-output-target/vue-component-lib/utils.ts#L88

This behavior works. However, it is not an ideal scenario because our internal event listener fires after any potential application event listener. This means that if an application logs the value of the reactive reference then they will get an outdated value. Since both the internal event listener and the application listener listen on the same element, the order in which they are added matters.

The application event listener is added first here: https://github.com/vuejs/core/blob/edf2572615d0b065bb7ae49de4c3b71086771310/packages/runtime-core/src/renderer.ts#L660-L670

And then the internal event listener is added after here in the `onVnodeBeforeMount` hook: https://github.com/vuejs/core/blob/edf2572615d0b065bb7ae49de4c3b71086771310/packages/runtime-core/src/renderer.ts#L686

-----

I had previously addressed this using an internal/external event architecture.

1. The Vue wrapper would listen for the internal event (i.e. `v-ion-change`): https://github.com/ionic-team/stencil-ds-output-targets/blob/1c8f4d475481c01937c970c09dce8586fa4bb179/packages/vue-output-target/vue-component-lib/utils.ts#L86
2. The wrapper would emit `update:modelValue`: https://github.com/ionic-team/stencil-ds-output-targets/blob/1c8f4d475481c01937c970c09dce8586fa4bb179/packages/vue-output-target/vue-component-lib/utils.ts#L88
3. Finally, it would emit the external event (i.e `ion-change`) causing the application event listener to fire after the reactive reference had been updated: https://github.com/ionic-team/stencil-ds-output-targets/blob/1c8f4d475481c01937c970c09dce8586fa4bb179/packages/vue-output-target/vue-component-lib/utils.ts#L99

This architecture relies on your Stencil component library knowing which events need to be emitted as the internal event. In other words, it needs to know that the `ionChange` event actually needs to emit as `v-ion-change`. This approach works well when all your `v-model` components listen on the same event. The architecture begins to break when the events differ. 

The problem is that the event emission configuration is [setup in the Vue project](https://github.com/ionic-team/ionic-framework/blob/89698b338fb05cde427c98720c238d2365abdaa7/packages/vue/src/ionic-vue.ts#L13-L23), but the list of components and their `v-model` events are [contained in the Stencil component project](https://github.com/ionic-team/ionic-framework/blob/89698b338fb05cde427c98720c238d2365abdaa7/core/stencil.config.ts#L196-L214). When all your `v-model` components are listening on the same event you can hard code the event configuration in the Vue project, but you cannot safely do that when these components are listening on different events.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This approach adds a custom directive to `v-model` components instead of relying on the `onVnodeBeforeMount` hook. When the `created` directive hook fires we setup the event listener. This ensures the internal event listener is fired first because the `created` callback is fired first in Vue: https://github.com/vuejs/core/blob/edf2572615d0b065bb7ae49de4c3b71086771310/packages/runtime-core/src/renderer.ts#L652

When the internal callback fires, we still emit `update:modelValue`. Since this callback happened before the application callback, the reactive reference is updated in time.

This approach means we no longer need the external event APIs, so that has been removed.

[Try a demo of the fix](https://play.vuejs.org/#eNqdVl2P0zgU/StX0UpJR23ywD6VdjS7w6yWFQsIRswDQSJNbttAYhvbaWdU9b9zbSepkxaE6EOV2PfrHN97nEPwlxDxrsFgHixULkuhQaFuxHXKylpwqeEAZPKSiUbDEdaS1xDGSbcUPvfsJK57Ewpp9lKWc6Y0lMb4Q1Y1CEtjF4XhxNvm7LZRmtcuzRIi3E1geQ2HlAEYE15hXPFNFL6jHDZOOPWCxjvzbyIeTdBF4qAQCHrRWIsq00hvAIsezG5W8wKrZRqc4qQB3OS2ErtGe4PKoj9wh0xP0uB60VNAYReJlyOYBo6RWZ2J+IvijLi1QCiT3VBpMHfQzBoxZd7TYKu1UPMkyQtGblRauZMxQ50wUSc3ZJbIhumyxlnB65tn8bP4z6QolfaXY1T1bCX5XqGkIGkw9dIktLhDOZPICpQofzXtyM1PPdo6S2+y05EciRSt6CDX5WZESc5rUVYo3whd0kEPqMmqiu//s2taNthjybeYf72w/kU9OkxvJdrKPPw6kxvUbvvu/Wt8pOd+kzqhqdpj+MHmO6QmbEyNzuzvhhVUtmdnq31pT7hkm3t196iRqQ6UKdSyYe3tedz+BPqpXGLbY7Hrulgr4rAfPVVx/U+VbdQ91d4NYRq449tmEos08Ee1wHXJbAGcUUdPYTuFfam3L0qJuS53qE5BbIOenPWTQIrw4TVNz7kRTXSVKdVrxsMtUEXUHgr+vf//1V2FNeXrcA5kgQi1VRU2jNm24iCbXHMZTTof81ONQFoiQ/NmZ948EGNglWBoLUnQJAO9LVV8yjh2JtlrnUl7PO+RGxW66wvsi3RIaM9af2tQPr3HiqikykO71+pd51WuIbLrg1w9J07QunhnRbeFD+p3MzhE3nozlIZ8Cvd54Qo1h0jqpm2nQ3L9+bchDcvOiuLOSOQrEgektJ3lFKiwTtBPP5coN0AZ7sFJrQ0QhZ4Ok/sBVs1qVaFykwRHP/cpP4mSyHS+dTFyeyX0hA36pe8wRpCwuKXpXWX51wv8dcSevG0AfLTj4CD0t8pyPFpRJCQXyiDAuqTZ9HlIEnhhzSkTwgOuoPczHcK4hqySmBVPbdiinRvqHsdPO1Aqpt6PwkyIWXs0sFx6IzVANfJ0Jr7z1BvfsyGraE7szfmWcHUjEbrL3mK6umpTXcHDFpnR69NRUretSWMUXfnnmHu/PVI/YAGaQyMKuletbXtjm+8HumxYjnHnkHh60cLrlYyq67HnxCUd9pw+MKpxP2J1oXuHTRjhHKzBpV4+4yTC2Kk4ZE78LKMt7RM34aMmNh0ShQ7y3AbsvnWG0S+29SVJsMJ3Nnrt+lDwo+2wBQ5ODedjYMfJ9OPHEcefPvnTMXkeHL8DPnRjqQ==)

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

The external event API has been removed because it is no longer needed.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
