### PR TITLE
chore: bump vue output target

### DIFF
--- a/packages/vue-output-target/package-lock.json
+++ b/packages/vue-output-target/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/vue-output-target",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"

--- a/packages/vue-output-target/package.json
+++ b/packages/vue-output-target/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Vue output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

According to https://github.com/ionic-team/stencil-ds-output-targets/pull/352, we need to bump the package.json after a package has been released.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Bumps the Vue package.json after the https://github.com/ionic-team/stencil-ds-output-targets/actions/runs/6667732913 release

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
