### PR TITLE
fix(angular): generate event type with inline types

### DIFF
--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -379,10 +379,12 @@ export declare interface MyComponent extends Components.MyComponent {
       expect(definition).toEqual(
         `import type { MyEvent as IMyComponentMyEvent } from '@ionic/core';
 import type { Currency as IMyComponentCurrency } from '@ionic/core';
+import type { Side as IMyComponentSide } from '@ionic/core';
 
 export declare interface MyComponent extends Components.MyComponent {
 
   myChange: EventEmitter<CustomEvent<IMyComponentMyEvent<IMyComponentCurrency>>>;
+
   mySwipe: EventEmitter<CustomEvent<{ side: IMyComponentSide }>>;
 }`
       );

--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -351,27 +351,27 @@ export declare interface MyComponent extends Components.MyComponent {
             internal: false,
           },
           {
-            name: "mySwipe",
-            method: "mySwipe",
+            name: 'mySwipe',
+            method: 'mySwipe',
             bubbles: true,
             cancelable: true,
             composed: true,
             docs: {
               tags: [],
-              text: ""
+              text: '',
             },
             complexType: {
-              original: "{ side: Side }",
-              resolved: "{ side: Side; }",
+              original: '{ side: Side }',
+              resolved: '{ side: Side; }',
               references: {
                 Side: {
-                  location: "import",
-                  path: "../../interfaces"
-                }
-              }
+                  location: 'import',
+                  path: '../../interfaces',
+                },
+              },
             },
-            internal: false
-          }
+            internal: false,
+          },
         ],
         '@ionic/core'
       );

--- a/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/packages/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -350,6 +350,28 @@ export declare interface MyComponent extends Components.MyComponent {
             },
             internal: false,
           },
+          {
+            name: "mySwipe",
+            method: "mySwipe",
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            docs: {
+              tags: [],
+              text: ""
+            },
+            complexType: {
+              original: "{ side: Side }",
+              resolved: "{ side: Side; }",
+              references: {
+                Side: {
+                  location: "import",
+                  path: "../../interfaces"
+                }
+              }
+            },
+            internal: false
+          }
         ],
         '@ionic/core'
       );
@@ -361,6 +383,7 @@ import type { Currency as IMyComponentCurrency } from '@ionic/core';
 export declare interface MyComponent extends Components.MyComponent {
 
   myChange: EventEmitter<CustomEvent<IMyComponentMyEvent<IMyComponentCurrency>>>;
+  mySwipe: EventEmitter<CustomEvent<{ side: IMyComponentSide }>>;
 }`
       );
     });

--- a/packages/angular-output-target/src/generate-angular-component.ts
+++ b/packages/angular-output-target/src/generate-angular-component.ts
@@ -107,8 +107,23 @@ const formatOutputType = (componentClassName: string, event: ComponentCompilerEv
       (type, [src, dst]) => {
         let renamedType = type;
         if (!type.startsWith(prefix)) {
-          renamedType = `I${componentClassName}${type}`;
+          if (type.startsWith('{') && type.endsWith('}')) {
+            /**
+             * If the type starts with { and ends with }, it is an inline type.
+             * For example, `{ a: string }`.
+             * We don't need to rename these types, so we return the original type.
+             */
+            renamedType = type;
+          } else {
+            /**
+             * If the type does not start with { and end with }, it is a reference type.
+             * For example, `MyType`.
+             * We need to rename these types, so we prepend the prefix.
+             */
+            renamedType = `I${componentClassName}${type}`;
+          }
         }
+
         return (
           renamedType
             .replace(new RegExp(`^${src}$`, 'g'), `${dst}`)


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

When adding a custom event with an inline type:
```
@Event() ionSwipe!: EventEmitter<{ side: Side }>;
```

The generated event type is invalid:
```
 ionSwipe: EventEmitter<CustomEvent<IIonItemOptions{ side: IIonItemOptionsSide }>>;
```

There are two issues:
1. The nested type argument is formatted incorrectly (missing <).
2. The evaluated type shouldn’t include `IIonItemOptions`.

Expected output is:
```
ionSwipe: EventEmitter<CustomEvent<{ side: IIonItemOptionsSide }>>;
```

Issue URL: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The generated event type will account for inline-types.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev-build: `0.0.1-dev.11705624885.1949250b`