### PR TITLE
chore(vue): bump package version

### DIFF
--- a/packages/vue-output-target/package-lock.json
+++ b/packages/vue-output-target/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/vue-output-target",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "peerDependencies": {
         "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"

--- a/packages/vue-output-target/package.json
+++ b/packages/vue-output-target/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Vue output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Bumps the Vue package version to match the latest release.