### PR TITLE
feat: add value accessors to the directives array

### DIFF
--- a/packages/angular-output-target/src/generate-angular-directives-file.ts
+++ b/packages/angular-output-target/src/generate-angular-directives-file.ts
@@ -1,25 +1,40 @@
 import type { OutputTargetAngular } from './types';
 import { dashToPascalCase, relativeImport } from './utils';
 import type { CompilerCtx, ComponentCompilerMeta } from '@stencil/core/internal';
+import path from 'path';
 
 export function generateAngularDirectivesFile(
   compilerCtx: CompilerCtx,
   components: ComponentCompilerMeta[],
-  outputTarget: OutputTargetAngular
+  outputTarget: OutputTargetAngular,
+  valueAccessorDirectiveClasses: string[] = []
 ): Promise<any> {
   // Only create the file if it is defined in the stencil configuration
   if (!outputTarget.directivesArrayFile) {
     return Promise.resolve();
   }
 
-  const proxyPath = relativeImport(outputTarget.directivesArrayFile, outputTarget.directivesProxyFile, '.ts');
+  const directivesProxyPath = relativeImport(outputTarget.directivesArrayFile, outputTarget.directivesProxyFile, '.ts');
   const directives = components
     .map((cmpMeta) => dashToPascalCase(cmpMeta.tagName))
     .map((className) => `d.${className}`)
     .join(',\n  ');
+  const valueAccessorsDirectivesFile = path.join(path.dirname(outputTarget.directivesProxyFile), 'value-accessor-directives.ts');
+  const valueAccessorsDirectivesProxyPath = relativeImport(outputTarget.directivesArrayFile, valueAccessorsDirectivesFile, '.ts');
+  const valueAccessors = valueAccessorDirectiveClasses
+    .map((className) => `va.${className}`)
+    .join(',\n  ');
 
-  const c = `
-import * as d from '${proxyPath}';
+  const c = valueAccessorDirectiveClasses.length > 0 ? `
+import * as d from '${directivesProxyPath}';
+import * as va from '${valueAccessorsDirectivesProxyPath}';
+
+export const DIRECTIVES = [
+  ${directives},
+  ${valueAccessors}
+];
+` : `
+import * as d from '${directivesProxyPath}';
 
 export const DIRECTIVES = [
   ${directives}

--- a/packages/angular-output-target/src/output-angular.ts
+++ b/packages/angular-output-target/src/output-angular.ts
@@ -28,12 +28,10 @@ export async function angularDirectiveProxyOutput(
 
   const finalText = generateProxies(filteredComponents, pkgData, outputTarget, config.rootDir as string);
 
-  await Promise.all([
-    compilerCtx.fs.writeFile(outputTarget.directivesProxyFile, finalText),
-    copyResources(config, outputTarget),
-    generateAngularDirectivesFile(compilerCtx, filteredComponents, outputTarget),
-    generateValueAccessors(compilerCtx, filteredComponents, outputTarget, config),
-  ]);
+  await compilerCtx.fs.writeFile(outputTarget.directivesProxyFile, finalText);
+  await copyResources(config, outputTarget);
+  const valueAccessorClasses = await generateValueAccessors(compilerCtx, filteredComponents, outputTarget, config);
+  await generateAngularDirectivesFile(compilerCtx, filteredComponents, outputTarget, valueAccessorClasses);
 }
 
 function getFilteredComponents(excludeComponents: string[] = [], cmps: ComponentCompilerMeta[]) {

--- a/packages/angular-output-target/tsconfig.json
+++ b/packages/angular-output-target/tsconfig.json
@@ -7,10 +7,10 @@
     "strict": true,
     "declaration": true,
     "experimentalDecorators": true,
-    "lib": ["dom", "es2017", "esnext.array"],
+    "lib": ["dom", "es2020", "esnext.array"],
     "moduleResolution": "node",
     "module": "esnext",
-    "target": "es2017",
+    "target": "es2020",
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "outDir": "dist"


### PR DESCRIPTION
The value accessor directives also need to be declared in the module file. This is achieved here by adding them to the directives array file, since it is assumed that the module declares and exports all elements of this array.

## Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The value accessor directives have to be added to the angular module manually.

Issue URL: https://github.com/ionic-team/stencil-ds-output-targets/issues/436

## What is the new behavior?
The value acessor directives are included in the directivesArrayFile and thereby declared and exported by a module file as described in the angular integration guide (https://stenciljs.com/docs/angular#adding-the-angular-output-target)

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

The value accessors need to be removed from the public-api exports, since they are not copied any more. 
The only export necessary hereafter is 
```
export * from './lib/stencil-generated/value-accessors';
```
This line should added to the angular integration guide (https://stenciljs.com/docs/angular#adding-the-angular-output-target)
