### PR TITLE
fix(vue): pass router-link value to href to properly render clickable elements

### DIFF
--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -114,6 +114,16 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
       const { routerLink } = props;
       if (routerLink === EMPTY_PROP) return;
 
+      /**
+       * This prevents the browser from
+       * performing a page reload when pressing
+       * an Ionic component with routerLink.
+       * The page reload interferes with routing
+       * and causes ion-back-button to disappear
+       * since the local history is wiped on reload.
+       */
+      ev.preventDefault();
+
       if (navManager !== undefined) {
         let navigationPayload: any = { event: ev };
         for (const key in props) {

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -185,6 +185,17 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
         }
       }
 
+      // If router link is defined, add href to props
+      // in order to properly render an anchor tag inside
+      // of components that should become activatable and
+      // focusable with router link.
+      if (props[ROUTER_LINK_VALUE] !== EMPTY_PROP) {
+        propsToAdd = {
+          ...propsToAdd,
+          href: props[ROUTER_LINK_VALUE],
+        };
+      }
+
       /**
        * vModelDirective is only needed on components that support v-model.
        * As a result, we conditionally call withDirectives with v-model components.

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -114,17 +114,17 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
       const { routerLink } = props;
       if (routerLink === EMPTY_PROP) return;
 
-      /**
-       * This prevents the browser from
-       * performing a page reload when pressing
-       * an Ionic component with routerLink.
-       * The page reload interferes with routing
-       * and causes ion-back-button to disappear
-       * since the local history is wiped on reload.
-       */
-      ev.preventDefault();
-
       if (navManager !== undefined) {
+        /**
+         * This prevents the browser from
+         * performing a page reload when pressing
+         * an Ionic component with routerLink.
+         * The page reload interferes with routing
+         * and causes ion-back-button to disappear
+         * since the local history is wiped on reload.
+         */
+        ev.preventDefault();
+
         let navigationPayload: any = { event: ev };
         for (const key in props) {
           const value = props[key];


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Ionic Framework Vue components using `router-link` do not apply an `href` property which causes components to render `div` or `button` elements when they should render an `a`. 

## What is the new behavior?
Check if `router-link` and `navManager` are defined so this only applies to Ionic Framework components. If both are defined then add the `href` property to the element with the value of `router-link`.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
