### PR TITLE
fix(react): decamelize all component props

### DIFF
--- a/packages/example-project/component-library-angular/src/directives/proxies.ts
+++ b/packages/example-project/component-library-angular/src/directives/proxies.ts
@@ -103,14 +103,14 @@ export declare interface MyCheckbox extends Components.MyCheckbox {
 }
 
 @ProxyCmp({
-  inputs: ['age', 'first', 'kidName', 'last', 'middle'],
+  inputs: ['age', 'favoriteKidName', 'first', 'kidsNames', 'last', 'middle'],
 })
 @Component({
   selector: 'my-component',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['age', 'first', 'kidName', 'last', 'middle'],
+  inputs: ['age', 'favoriteKidName', 'first', 'kidsNames', 'last', 'middle'],
 })
 export class MyComponent {
   protected el: HTMLElement;

--- a/packages/example-project/component-library-angular/src/directives/proxies.ts
+++ b/packages/example-project/component-library-angular/src/directives/proxies.ts
@@ -103,14 +103,14 @@ export declare interface MyCheckbox extends Components.MyCheckbox {
 }
 
 @ProxyCmp({
-  inputs: ['age', 'first', 'kidsNames', 'last', 'middle'],
+  inputs: ['age', 'first', 'kidName', 'last', 'middle'],
 })
 @Component({
   selector: 'my-component',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['age', 'first', 'kidsNames', 'last', 'middle'],
+  inputs: ['age', 'first', 'kidName', 'last', 'middle'],
 })
 export class MyComponent {
   protected el: HTMLElement;

--- a/packages/example-project/component-library-vue/src/proxies.ts
+++ b/packages/example-project/component-library-vue/src/proxies.ts
@@ -36,7 +36,8 @@ export const MyComponent = /*@__PURE__*/ defineContainer<JSX.MyComponent>('my-co
   'middle',
   'last',
   'age',
-  'kidName',
+  'kidsNames',
+  'favoriteKidName',
   'myCustomEvent',
 ]);
 

--- a/packages/example-project/component-library-vue/src/proxies.ts
+++ b/packages/example-project/component-library-vue/src/proxies.ts
@@ -36,7 +36,7 @@ export const MyComponent = /*@__PURE__*/ defineContainer<JSX.MyComponent>('my-co
   'middle',
   'last',
   'age',
-  'kidsNames',
+  'kidName',
   'myCustomEvent',
 ]);
 

--- a/packages/example-project/component-library/src/components.d.ts
+++ b/packages/example-project/component-library/src/components.d.ts
@@ -116,7 +116,7 @@ export namespace Components {
         /**
           * The array of child names
          */
-        "kidsNames": string[];
+        "kidName": string;
         /**
           * The last name
          */
@@ -716,7 +716,7 @@ declare namespace LocalJSX {
         /**
           * The array of child names
          */
-        "kidsNames"?: string[];
+        "kidName"?: string;
         /**
           * The last name
          */

--- a/packages/example-project/component-library/src/components.d.ts
+++ b/packages/example-project/component-library/src/components.d.ts
@@ -110,13 +110,17 @@ export namespace Components {
          */
         "age": number;
         /**
+          * The favorite kid
+         */
+        "favoriteKidName": string;
+        /**
           * The first name
          */
         "first": string;
         /**
           * The array of child names
          */
-        "kidName": string;
+        "kidsNames": string[];
         /**
           * The last name
          */
@@ -710,13 +714,17 @@ declare namespace LocalJSX {
          */
         "age"?: number;
         /**
+          * The favorite kid
+         */
+        "favoriteKidName"?: string;
+        /**
           * The first name
          */
         "first"?: string;
         /**
           * The array of child names
          */
-        "kidName"?: string;
+        "kidsNames"?: string[];
         /**
           * The last name
          */

--- a/packages/example-project/component-library/src/components/my-component/my-component.tsx
+++ b/packages/example-project/component-library/src/components/my-component/my-component.tsx
@@ -29,7 +29,12 @@ export class MyComponent {
   /**
    * The array of child names
    */
-  @Prop() kidName: string;
+  @Prop() kidsNames: string[];
+
+  /**
+   * The favorite kid
+   */
+  @Prop() favoriteKidName: string;
 
   /**
    * Testing an event without value
@@ -49,7 +54,8 @@ export class MyComponent {
       <div onClick={this.emitCustomEvent.bind(this)}>
         Hello, World! I'm {this.getText()}
         <p>Age: {this.age}</p>
-        <p>Kid: {this.kidName}</p>
+        <p>Kids: {this.kidsNames?.join(', ')}</p>
+        <p>Favorite kid: {this.favoriteKidName}</p>
       </div>
     );
   }

--- a/packages/example-project/component-library/src/components/my-component/my-component.tsx
+++ b/packages/example-project/component-library/src/components/my-component/my-component.tsx
@@ -29,7 +29,7 @@ export class MyComponent {
   /**
    * The array of child names
    */
-  @Prop() kidsNames: string[];
+  @Prop() kidName: string;
 
   /**
    * Testing an event without value
@@ -45,6 +45,12 @@ export class MyComponent {
   }
 
   render() {
-    return <div onClick={this.emitCustomEvent.bind(this)}>Hello, World! I'm {this.getText()}</div>;
+    return (
+      <div onClick={this.emitCustomEvent.bind(this)}>
+        Hello, World! I'm {this.getText()}
+        <p>Age: {this.age}</p>
+        <p>Kid: {this.kidName}</p>
+      </div>
+    );
   }
 }

--- a/packages/example-project/component-library/src/components/my-component/readme.md
+++ b/packages/example-project/component-library/src/components/my-component/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property  | Attribute  | Description              | Type     | Default     |
-| --------- | ---------- | ------------------------ | -------- | ----------- |
-| `age`     | `age`      | The age                  | `number` | `undefined` |
-| `first`   | `first`    | The first name           | `string` | `undefined` |
-| `kidName` | `kid-name` | The array of child names | `string` | `undefined` |
-| `last`    | `last`     | The last name            | `string` | `undefined` |
-| `middle`  | `middle`   | The middle name          | `string` | `undefined` |
+| Property          | Attribute           | Description              | Type       | Default     |
+| ----------------- | ------------------- | ------------------------ | ---------- | ----------- |
+| `age`             | `age`               | The age                  | `number`   | `undefined` |
+| `favoriteKidName` | `favorite-kid-name` | The favorite kid         | `string`   | `undefined` |
+| `first`           | `first`             | The first name           | `string`   | `undefined` |
+| `kidsNames`       | --                  | The array of child names | `string[]` | `undefined` |
+| `last`            | `last`              | The last name            | `string`   | `undefined` |
+| `middle`          | `middle`            | The middle name          | `string`   | `undefined` |
 
 
 ## Events

--- a/packages/example-project/component-library/src/components/my-component/readme.md
+++ b/packages/example-project/component-library/src/components/my-component/readme.md
@@ -7,13 +7,13 @@
 
 ## Properties
 
-| Property    | Attribute | Description              | Type       | Default     |
-| ----------- | --------- | ------------------------ | ---------- | ----------- |
-| `age`       | `age`     | The age                  | `number`   | `undefined` |
-| `first`     | `first`   | The first name           | `string`   | `undefined` |
-| `kidsNames` | --        | The array of child names | `string[]` | `undefined` |
-| `last`      | `last`    | The last name            | `string`   | `undefined` |
-| `middle`    | `middle`  | The middle name          | `string`   | `undefined` |
+| Property  | Attribute  | Description              | Type     | Default     |
+| --------- | ---------- | ------------------------ | -------- | ----------- |
+| `age`     | `age`      | The age                  | `number` | `undefined` |
+| `first`   | `first`    | The first name           | `string` | `undefined` |
+| `kidName` | `kid-name` | The array of child names | `string` | `undefined` |
+| `last`    | `last`     | The last name            | `string` | `undefined` |
+| `middle`  | `middle`   | The middle name          | `string` | `undefined` |
 
 
 ## Events

--- a/packages/example-project/next-app/src/app/page.tsx
+++ b/packages/example-project/next-app/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
         first="Stencil"
         last="'Don't call me a framework' JS"
         className="my-8"
-        kidName="foobar"
+        favoriteKidName="foobar"
       />
       <hr />
       <MyRange name="myRange">Hello World</MyRange>

--- a/packages/example-project/next-app/src/app/page.tsx
+++ b/packages/example-project/next-app/src/app/page.tsx
@@ -13,6 +13,7 @@ export default function Home() {
         first="Stencil"
         last="'Don't call me a framework' JS"
         className="my-8"
+        kidName="foobar"
       />
       <hr />
       <MyRange name="myRange">Hello World</MyRange>

--- a/packages/example-project/next-app/test/specs/test.e2e.mts
+++ b/packages/example-project/next-app/test/specs/test.e2e.mts
@@ -34,6 +34,6 @@ describe('Stencil NextJS Integration', () => {
   });
 
   it('should transform camelCase into kebab-case', async () => {
-    await expect($('my-component[kid-name="foobar"]')).toBePresent();
+    await expect($('my-component[favorite-kid-name="foobar"]')).toBePresent();
   });
 });

--- a/packages/example-project/next-app/test/specs/test.e2e.mts
+++ b/packages/example-project/next-app/test/specs/test.e2e.mts
@@ -31,5 +31,9 @@ describe('Stencil NextJS Integration', () => {
 
   it('should transform react properties into html attributes', async () => {
     await expect($('my-component.my-8')).toBePresent();
-  })
+  });
+
+  it('should transform camelCase into kebab-case', async () => {
+    await expect($('my-component[kid-name="foobar"]')).toBePresent();
+  });
 });

--- a/packages/react-output-target/package.json
+++ b/packages/react-output-target/package.json
@@ -51,6 +51,7 @@
   "gitHead": "a3588e905186a0e86e7f88418fd5b2f9531b55e0",
   "dependencies": {
     "@lit/react": "^1.0.4",
+    "decamelize": "^6.0.0",
     "html-react-parser": "^5.1.10",
     "react-dom": "^18.3.1",
     "ts-morph": "^22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       '@stencil/core':
         specifier: '>=3 || >= 4.0.0-beta.0 || >= 4.0.0'
         version: 4.19.0
+      decamelize:
+        specifier: ^6.0.0
+        version: 6.0.0
       html-react-parser:
         specifier: ^5.1.10
         version: 5.1.12(@types/react@18.3.3)(react@18.3.1)
@@ -17379,7 +17382,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -17403,7 +17406,7 @@ snapshots:
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.14.0
@@ -17425,7 +17428,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -19349,7 +19352,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3
+      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2))
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -19755,29 +19758,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-jasmine2@26.6.3:
-    dependencies:
-      '@babel/traverse': 7.24.7
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 20.14.12
-      chalk: 4.1.2
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2))
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@4.9.5)):
     dependencies:
       '@babel/traverse': 7.24.7
@@ -19794,6 +19774,33 @@ snapshots:
       jest-matcher-utils: 26.6.2
       jest-message-util: 26.6.2
       jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@4.9.5))
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      pretty-format: 26.6.2
+      throat: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+
+  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2)):
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@jest/environment': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 20.14.12
+      chalk: 4.1.2
+      co: 4.6.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2))
       jest-snapshot: 26.6.2
       jest-util: 26.6.2
       pretty-format: 26.6.2


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

if a Stencil component has a property like `toggleStyle`, it would cause it to not being serialized correctly to `toggle-style` in the server rendered HTML code.

## What is the new behavior?

This patch decamelizes all properties.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I changed the `kidsNames` property to `kidName` as arrays can't be properly serialized in React.
