### PR TITLE
fix(react-output-target): event name alignment to underscore

### DIFF
--- a/packages/react-output-target/src/react-output-target/utils/string-utils.test.ts
+++ b/packages/react-output-target/src/react-output-target/utils/string-utils.test.ts
@@ -21,6 +21,7 @@ describe('string-utils', () => {
       expect(eventListenerName('my-event')).toEqual('onMyEvent');
       expect(eventListenerName('myevent')).toEqual('onMyevent');
       expect(eventListenerName('myEvent')).toEqual('onMyEvent');
+      expect(eventListenerName('_myEvent')).toEqual('on_myEvent');
     });
   });
 });

--- a/packages/react-output-target/src/react-output-target/utils/string-utils.ts
+++ b/packages/react-output-target/src/react-output-target/utils/string-utils.ts
@@ -5,6 +5,6 @@ export const kebabToPascalCase = (str: string) =>
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join('');
 
-export const kebabToCamelCase = (str: string) => str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+export const kebabToCamelCase = (str: string) => str.replace(/-([_ a-z])/g, (_, letter) => letter.toUpperCase());
 
 export const eventListenerName = (eventName: string) => kebabToCamelCase(`on-${eventName}`);

--- a/packages/react-output-target/src/react-output-target/utils/string-utils.ts
+++ b/packages/react-output-target/src/react-output-target/utils/string-utils.ts
@@ -5,7 +5,7 @@ export const kebabToPascalCase = (str: string) =>
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join('');
 
-export const kebabToCamelCase = (str: string) => str.replace(/-([_ a-z])/g, (_, letter) => letter.toUpperCase());
+export const kebabToCamelCase = (str: string) => str.replace(/-([_a-z])/g, (_, letter) => letter.toUpperCase());
 
 const slashesToCamelCase = (str: string) => str.replace(/\/([a-z])/g, (_, letter) => letter.toUpperCase());
 


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Stencil event name start with underscore, react output target isn't generated properly

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL:

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Stencil event name start with underscore, react output target generated properly
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
