### PR TITLE
fix(react): use property mapping from component meta

### DIFF
--- a/packages/react-output-target/package.json
+++ b/packages/react-output-target/package.json
@@ -16,7 +16,7 @@
     "prepublishOnly": "pnpm run build",
     "build": "vite build && pnpm run build:dts",
     "build:dts": "tsc -p tsconfig.json",
-    "build:tsup": "tsup",
+    "dev": "vite build --watch",
     "version": "pnpm run build",
     "prettier": "prettier \"./src/**/*.{html,ts,tsx,js,jsx}\" --write",
     "release": "np",
@@ -51,7 +51,6 @@
   "gitHead": "a3588e905186a0e86e7f88418fd5b2f9531b55e0",
   "dependencies": {
     "@lit/react": "^1.0.4",
-    "decamelize": "^6.0.0",
     "html-react-parser": "^5.1.10",
     "react-dom": "^18.3.1",
     "ts-morph": "^22.0.0"

--- a/packages/react-output-target/src/react-output-target/create-component-wrappers.test.ts
+++ b/packages/react-output-target/src/react-output-target/create-component-wrappers.test.ts
@@ -233,6 +233,8 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
           properties: [{
             name: 'hasMaxLength',
             attribute: 'max-length'
+          }, {
+            name: 'links'
           }],
           events: [
             {

--- a/packages/react-output-target/src/react-output-target/create-component-wrappers.test.ts
+++ b/packages/react-output-target/src/react-output-target/create-component-wrappers.test.ts
@@ -11,6 +11,7 @@ describe('createComponentWrappers', () => {
         {
           tagName: 'my-component',
           componentClassName: 'MyComponent',
+          properties: [],
           events: [
             {
               originalName: 'my-event',
@@ -62,6 +63,7 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
         {
           tagName: 'my-component',
           componentClassName: 'MyComponent',
+          properties: [],
           events: [
             {
               originalName: 'my-event',
@@ -115,6 +117,7 @@ export default MyComponent;
       components: [
         {
           tagName: 'my-component',
+          properties: [],
           internal: true,
         } as any,
       ],
@@ -162,6 +165,7 @@ export default MyComponent;
         {
           tagName: 'my-component',
           componentClassName: 'MyComponent',
+          properties: [],
           events: [
             {
               originalName: 'my-event',
@@ -226,6 +230,10 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
         {
           tagName: 'my-component',
           componentClassName: 'MyComponent',
+          properties: [{
+            name: 'hasMaxLength',
+            attribute: 'max-length'
+          }],
           events: [
             {
               originalName: 'my-event',
@@ -273,6 +281,7 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     })
     : /*@__PURE__*/ createSSRComponent<MyComponentElement, MyComponentEvents>({
         tagName: 'my-component',
+        properties: { hasMaxLength: 'max-length' },
         hydrateModule: import('my-package/hydrate')
     });
 

--- a/packages/react-output-target/src/react-output-target/create-stencil-react-components.ts
+++ b/packages/react-output-target/src/react-output-target/create-stencil-react-components.ts
@@ -151,6 +151,7 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
   })`;
     const serverComponentCall = `/*@__PURE__*/ createSSRComponent<${componentElement}, ${componentEventNamesType}>({
     tagName: '${tagName}',
+    properties: {${component.properties.map((e) => `${e.name}: '${e.attribute}'`).join(',\n')}},
     hydrateModule: import('${hydrateModule}')
   })`;
 

--- a/packages/react-output-target/src/react-output-target/create-stencil-react-components.ts
+++ b/packages/react-output-target/src/react-output-target/create-stencil-react-components.ts
@@ -151,7 +151,15 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
   })`;
     const serverComponentCall = `/*@__PURE__*/ createSSRComponent<${componentElement}, ${componentEventNamesType}>({
     tagName: '${tagName}',
-    properties: {${component.properties.map((e) => `${e.name}: '${e.attribute}'`).join(',\n')}},
+    properties: {${component.properties
+      /**
+       * Filter out properties that don't have an attribute.
+       * These are properties with complex types and can't be serialized.
+       */
+      .filter((prop) => Boolean(prop.attribute))
+      .map((e) => `${e.name}: '${e.attribute}'`)
+      .join(',\n')
+    }},
     hydrateModule: import('${hydrateModule}')
   })`;
 

--- a/packages/react-output-target/src/react/create-component.ts
+++ b/packages/react-output-target/src/react/create-component.ts
@@ -27,9 +27,11 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
  */
 export const createSSRComponent = <I extends HTMLElement, E extends EventNames = {}>({
   hydrateModule,
+  properties,
   tagName,
 }: {
   hydrateModule: Promise<{ renderToString: RenderToString }>;
+  properties: Record<string, string>;
   tagName: string;
 }): ReactWebComponent<I, E> => {
   /**
@@ -43,6 +45,7 @@ export const createSSRComponent = <I extends HTMLElement, E extends EventNames =
     const { createComponentForServerSideRendering } = await import('./ssr');
     return createComponentForServerSideRendering<I, E>({
       tagName,
+      properties,
       renderToString: (await hydrateModule).renderToString,
     })(props as any);
   }) as unknown as ReactWebComponent<I, E>;

--- a/packages/react-output-target/src/react/ssr.tsx
+++ b/packages/react-output-target/src/react/ssr.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import decamelize from 'decamelize';
 import type { EventName, ReactWebComponent, WebComponentProps } from '@lit/react';
 
 import { possibleStandardNames } from './constants';
@@ -19,6 +18,7 @@ interface RenderToStringOptions {
 export type RenderToString = (html: string, options: RenderToStringOptions) => Promise<{ html: string | null }>;
 interface CreateComponentForServerSideRenderingOptions {
   tagName: string;
+  properties: Record<string, string>;
   renderToString: RenderToString;
 }
 
@@ -59,8 +59,7 @@ export const createComponentForServerSideRendering = <I extends HTMLElement, E e
         continue;
       }
 
-      const propName =
-        possibleStandardNames[key as keyof typeof possibleStandardNames] || decamelize(key, { separator: '-' });
+      let propName = possibleStandardNames[key as keyof typeof possibleStandardNames] || options.properties[key] || key;
       stringProps += ` ${propName}=${propValue}`;
     }
 

--- a/packages/react-output-target/src/react/ssr.tsx
+++ b/packages/react-output-target/src/react/ssr.tsx
@@ -65,7 +65,7 @@ export const createComponentForServerSideRendering = <I extends HTMLElement, E e
       if (!propName) {
         console.warn(
           `${LOG_PREFIX} ignore component property "${key}" for ${options.tagName} ` +
-          '- property type is not a primitive and can\'t be serialized'
+          '- property type is unknown or not a primitive and can\'t be serialized'
         );
         continue;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,9 +346,6 @@ importers:
       '@stencil/core':
         specifier: '>=3 || >= 4.0.0-beta.0 || >= 4.0.0'
         version: 4.19.0
-      decamelize:
-        specifier: ^6.0.0
-        version: 6.0.0
       html-react-parser:
         specifier: ^5.1.10
         version: 5.1.12(@types/react@18.3.3)(react@18.3.1)
@@ -19352,7 +19349,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -19758,6 +19755,29 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  jest-jasmine2@26.6.3:
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@jest/environment': 26.6.2
+      '@jest/source-map': 26.6.2
+      '@jest/test-result': 26.6.2
+      '@jest/types': 26.6.2
+      '@types/node': 20.14.12
+      chalk: 4.1.2
+      co: 4.6.0
+      expect: 26.6.2
+      is-generator-fn: 2.1.0
+      jest-each: 26.6.2
+      jest-matcher-utils: 26.6.2
+      jest-message-util: 26.6.2
+      jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2))
+      jest-snapshot: 26.6.2
+      jest-util: 26.6.2
+      pretty-format: 26.6.2
+      throat: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@4.9.5)):
     dependencies:
       '@babel/traverse': 7.24.7
@@ -19774,33 +19794,6 @@ snapshots:
       jest-matcher-utils: 26.6.2
       jest-message-util: 26.6.2
       jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@4.9.5))
-      jest-snapshot: 26.6.2
-      jest-util: 26.6.2
-      pretty-format: 26.6.2
-      throat: 5.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - ts-node
-      - utf-8-validate
-
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2)):
-    dependencies:
-      '@babel/traverse': 7.24.7
-      '@jest/environment': 26.6.2
-      '@jest/source-map': 26.6.2
-      '@jest/test-result': 26.6.2
-      '@jest/types': 26.6.2
-      '@types/node': 20.14.12
-      chalk: 4.1.2
-      co: 4.6.0
-      expect: 26.6.2
-      is-generator-fn: 2.1.0
-      jest-each: 26.6.2
-      jest-matcher-utils: 26.6.2
-      jest-message-util: 26.6.2
-      jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.6.5)(@types/node@22.4.1)(typescript@5.5.2))
       jest-snapshot: 26.6.2
       jest-util: 26.6.2
       pretty-format: 26.6.2


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When server side rendering SSR components, we currently de-camelize the property name which is a wrong assumption, given Stencil user give their properties arbitrary names, e.g. when the `attribute` property is used:

```ts
@Prop({ attribute: 'multi-line', reflect: true, mutable: true }) isMultiLine: boolean = false;
```

## What is the new behavior?

The patch makes the output target pass along the mapping for attributes that Stencil then uses later when it hydrates the component.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

n/a
