### PR TITLE
fix(react): propagate slot property when hydrating

### DIFF
--- a/packages/react-output-target/src/react/constants.ts
+++ b/packages/react-output-target/src/react/constants.ts
@@ -153,6 +153,7 @@ export const possibleStandardNames = {
   requiredExtensions: 'requiredextensions',
   requiredFeatures: 'requiredfeatures',
   shapeRendering: 'shape-rendering',
+  slot: 'slot',
   specularConstant: 'specularconstant',
   specularExponent: 'specularexponent',
   spreadMethod: 'spreadmethod',


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We supress the `slot` property from being applied to the hydrated component. This is problematic as users may want to verify whether there is an element with such component.

## What is the new behavior?

Propagate this attribute and serialize it.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
