### PR TITLE
fix(#470): add quasi unique id when creating react SSR component 

### DIFF
--- a/packages/example-project/component-library-react/src/components.ts
+++ b/packages/example-project/component-library-react/src/components.ts
@@ -9,200 +9,143 @@
 
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent } from '@stencil/react-output-target/runtime';
-import {
-  type CheckboxChangeEventDetail,
-  type InputChangeEventDetail,
-  type MyCheckboxCustomEvent,
-  type MyInputCustomEvent,
-  type MyPopoverCustomEvent,
-  type MyRadioGroupCustomEvent,
-  type MyRangeCustomEvent,
-  type OverlayEventDetail,
-  type RadioGroupChangeEventDetail,
-  type RangeChangeEventDetail,
-} from 'component-library';
-import {
-  MyButton as MyButtonElement,
-  defineCustomElement as defineMyButton,
-} from 'component-library/components/my-button.js';
-import {
-  MyCheckbox as MyCheckboxElement,
-  defineCustomElement as defineMyCheckbox,
-} from 'component-library/components/my-checkbox.js';
-import {
-  MyComponent as MyComponentElement,
-  defineCustomElement as defineMyComponent,
-} from 'component-library/components/my-component.js';
-import {
-  MyInput as MyInputElement,
-  defineCustomElement as defineMyInput,
-} from 'component-library/components/my-input.js';
-import {
-  MyPopover as MyPopoverElement,
-  defineCustomElement as defineMyPopover,
-} from 'component-library/components/my-popover.js';
-import {
-  MyRadioGroup as MyRadioGroupElement,
-  defineCustomElement as defineMyRadioGroup,
-} from 'component-library/components/my-radio-group.js';
-import {
-  MyRadio as MyRadioElement,
-  defineCustomElement as defineMyRadio,
-} from 'component-library/components/my-radio.js';
-import {
-  MyRange as MyRangeElement,
-  defineCustomElement as defineMyRange,
-} from 'component-library/components/my-range.js';
+import { type CheckboxChangeEventDetail, type InputChangeEventDetail, type MyCheckboxCustomEvent, type MyInputCustomEvent, type MyPopoverCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
+import { MyButton as MyButtonElement, defineCustomElement as defineMyButton } from "component-library/components/my-button.js";
+import { MyCheckbox as MyCheckboxElement, defineCustomElement as defineMyCheckbox } from "component-library/components/my-checkbox.js";
+import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "component-library/components/my-component.js";
+import { MyInput as MyInputElement, defineCustomElement as defineMyInput } from "component-library/components/my-input.js";
+import { MyPopover as MyPopoverElement, defineCustomElement as defineMyPopover } from "component-library/components/my-popover.js";
+import { MyRadioGroup as MyRadioGroupElement, defineCustomElement as defineMyRadioGroup } from "component-library/components/my-radio-group.js";
+import { MyRadio as MyRadioElement, defineCustomElement as defineMyRadio } from "component-library/components/my-radio.js";
+import { MyRange as MyRangeElement, defineCustomElement as defineMyRange } from "component-library/components/my-range.js";
 import React from 'react';
 
 type MyButtonEvents = {
-  onMyFocus: EventName<CustomEvent<void>>;
-  onMyBlur: EventName<CustomEvent<void>>;
+    onMyFocus: EventName<CustomEvent<void>>,
+    onMyBlur: EventName<CustomEvent<void>>
 };
 
-export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = /*@__PURE__*/ createComponent<
-  MyButtonElement,
-  MyButtonEvents
->({
-  tagName: 'my-button',
-  elementClass: MyButtonElement,
-  react: React,
-  events: {
-    onMyFocus: 'myFocus',
-    onMyBlur: 'myBlur',
-  } as MyButtonEvents,
-  defineCustomElement: defineMyButton,
+export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = /*@__PURE__*/ createComponent<MyButtonElement, MyButtonEvents>({
+    tagName: 'my-button',
+    elementClass: MyButtonElement,
+    react: React,
+    events: {
+        onMyFocus: 'myFocus',
+        onMyBlur: 'myBlur'
+    } as MyButtonEvents,
+    defineCustomElement: defineMyButton
 });
 
 type MyCheckboxEvents = {
-  onMyChange: EventName<MyCheckboxCustomEvent<CheckboxChangeEventDetail>>;
-  onMyFocus: EventName<CustomEvent<void>>;
-  onMyBlur: EventName<CustomEvent<void>>;
+    onMyChange: EventName<MyCheckboxCustomEvent<CheckboxChangeEventDetail>>,
+    onMyFocus: EventName<CustomEvent<void>>,
+    onMyBlur: EventName<CustomEvent<void>>
 };
 
-export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEvents> = /*@__PURE__*/ createComponent<
-  MyCheckboxElement,
-  MyCheckboxEvents
->({
-  tagName: 'my-checkbox',
-  elementClass: MyCheckboxElement,
-  react: React,
-  events: {
-    onMyChange: 'myChange',
-    onMyFocus: 'myFocus',
-    onMyBlur: 'myBlur',
-  } as MyCheckboxEvents,
-  defineCustomElement: defineMyCheckbox,
+export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEvents> = /*@__PURE__*/ createComponent<MyCheckboxElement, MyCheckboxEvents>({
+    tagName: 'my-checkbox',
+    elementClass: MyCheckboxElement,
+    react: React,
+    events: {
+        onMyChange: 'myChange',
+        onMyFocus: 'myFocus',
+        onMyBlur: 'myBlur'
+    } as MyCheckboxEvents,
+    defineCustomElement: defineMyCheckbox
 });
 
 type MyComponentEvents = { onMyCustomEvent: EventName<CustomEvent<number>> };
 
-export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents> = /*@__PURE__*/ createComponent<
-  MyComponentElement,
-  MyComponentEvents
->({
-  tagName: 'my-component',
-  elementClass: MyComponentElement,
-  react: React,
-  events: { onMyCustomEvent: 'myCustomEvent' } as MyComponentEvents,
-  defineCustomElement: defineMyComponent,
+export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents>({
+    tagName: 'my-component',
+    elementClass: MyComponentElement,
+    react: React,
+    events: { onMyCustomEvent: 'myCustomEvent' } as MyComponentEvents,
+    defineCustomElement: defineMyComponent
 });
 
 type MyInputEvents = {
-  onMyInput: EventName<MyInputCustomEvent<KeyboardEvent>>;
-  onMyChange: EventName<MyInputCustomEvent<InputChangeEventDetail>>;
-  onMyBlur: EventName<CustomEvent<void>>;
-  onMyFocus: EventName<CustomEvent<void>>;
+    onMyInput: EventName<MyInputCustomEvent<KeyboardEvent>>,
+    onMyChange: EventName<MyInputCustomEvent<InputChangeEventDetail>>,
+    onMyBlur: EventName<CustomEvent<void>>,
+    onMyFocus: EventName<CustomEvent<void>>
 };
 
-export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@__PURE__*/ createComponent<
-  MyInputElement,
-  MyInputEvents
->({
-  tagName: 'my-input',
-  elementClass: MyInputElement,
-  react: React,
-  events: {
-    onMyInput: 'myInput',
-    onMyChange: 'myChange',
-    onMyBlur: 'myBlur',
-    onMyFocus: 'myFocus',
-  } as MyInputEvents,
-  defineCustomElement: defineMyInput,
+export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@__PURE__*/ createComponent<MyInputElement, MyInputEvents>({
+    tagName: 'my-input',
+    elementClass: MyInputElement,
+    react: React,
+    events: {
+        onMyInput: 'myInput',
+        onMyChange: 'myChange',
+        onMyBlur: 'myBlur',
+        onMyFocus: 'myFocus'
+    } as MyInputEvents,
+    defineCustomElement: defineMyInput
 });
 
 type MyPopoverEvents = {
-  onMyPopoverDidPresent: EventName<CustomEvent<void>>;
-  onMyPopoverWillPresent: EventName<CustomEvent<void>>;
-  onMyPopoverWillDismiss: EventName<MyPopoverCustomEvent<OverlayEventDetail>>;
-  onMyPopoverDidDismiss: EventName<MyPopoverCustomEvent<OverlayEventDetail>>;
+    onMyPopoverDidPresent: EventName<CustomEvent<void>>,
+    onMyPopoverWillPresent: EventName<CustomEvent<void>>,
+    onMyPopoverWillDismiss: EventName<MyPopoverCustomEvent<OverlayEventDetail>>,
+    onMyPopoverDidDismiss: EventName<MyPopoverCustomEvent<OverlayEventDetail>>
 };
 
-export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents> = /*@__PURE__*/ createComponent<
-  MyPopoverElement,
-  MyPopoverEvents
->({
-  tagName: 'my-popover',
-  elementClass: MyPopoverElement,
-  react: React,
-  events: {
-    onMyPopoverDidPresent: 'myPopoverDidPresent',
-    onMyPopoverWillPresent: 'myPopoverWillPresent',
-    onMyPopoverWillDismiss: 'myPopoverWillDismiss',
-    onMyPopoverDidDismiss: 'myPopoverDidDismiss',
-  } as MyPopoverEvents,
-  defineCustomElement: defineMyPopover,
+export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents> = /*@__PURE__*/ createComponent<MyPopoverElement, MyPopoverEvents>({
+    tagName: 'my-popover',
+    elementClass: MyPopoverElement,
+    react: React,
+    events: {
+        onMyPopoverDidPresent: 'myPopoverDidPresent',
+        onMyPopoverWillPresent: 'myPopoverWillPresent',
+        onMyPopoverWillDismiss: 'myPopoverWillDismiss',
+        onMyPopoverDidDismiss: 'myPopoverDidDismiss'
+    } as MyPopoverEvents,
+    defineCustomElement: defineMyPopover
 });
 
 type MyRadioEvents = {
-  onMyFocus: EventName<CustomEvent<void>>;
-  onMyBlur: EventName<CustomEvent<void>>;
-  onMySelect: EventName<CustomEvent<void>>;
+    onMyFocus: EventName<CustomEvent<void>>,
+    onMyBlur: EventName<CustomEvent<void>>,
+    onMySelect: EventName<CustomEvent<void>>
 };
 
-export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = /*@__PURE__*/ createComponent<
-  MyRadioElement,
-  MyRadioEvents
->({
-  tagName: 'my-radio',
-  elementClass: MyRadioElement,
-  react: React,
-  events: {
-    onMyFocus: 'myFocus',
-    onMyBlur: 'myBlur',
-    onMySelect: 'mySelect',
-  } as MyRadioEvents,
-  defineCustomElement: defineMyRadio,
+export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = /*@__PURE__*/ createComponent<MyRadioElement, MyRadioEvents>({
+    tagName: 'my-radio',
+    elementClass: MyRadioElement,
+    react: React,
+    events: {
+        onMyFocus: 'myFocus',
+        onMyBlur: 'myBlur',
+        onMySelect: 'mySelect'
+    } as MyRadioEvents,
+    defineCustomElement: defineMyRadio
 });
 
 type MyRadioGroupEvents = { onMyChange: EventName<MyRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
 
-export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents> =
-  /*@__PURE__*/ createComponent<MyRadioGroupElement, MyRadioGroupEvents>({
+export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents> = /*@__PURE__*/ createComponent<MyRadioGroupElement, MyRadioGroupEvents>({
     tagName: 'my-radio-group',
     elementClass: MyRadioGroupElement,
     react: React,
     events: { onMyChange: 'myChange' } as MyRadioGroupEvents,
-    defineCustomElement: defineMyRadioGroup,
-  });
+    defineCustomElement: defineMyRadioGroup
+});
 
 type MyRangeEvents = {
-  onMyChange: EventName<MyRangeCustomEvent<RangeChangeEventDetail>>;
-  onMyFocus: EventName<CustomEvent<void>>;
-  onMyBlur: EventName<CustomEvent<void>>;
+    onMyChange: EventName<MyRangeCustomEvent<RangeChangeEventDetail>>,
+    onMyFocus: EventName<CustomEvent<void>>,
+    onMyBlur: EventName<CustomEvent<void>>
 };
 
-export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@__PURE__*/ createComponent<
-  MyRangeElement,
-  MyRangeEvents
->({
-  tagName: 'my-range',
-  elementClass: MyRangeElement,
-  react: React,
-  events: {
-    onMyChange: 'myChange',
-    onMyFocus: 'myFocus',
-    onMyBlur: 'myBlur',
-  } as MyRangeEvents,
-  defineCustomElement: defineMyRange,
+export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@__PURE__*/ createComponent<MyRangeElement, MyRangeEvents>({
+    tagName: 'my-range',
+    elementClass: MyRangeElement,
+    react: React,
+    events: {
+        onMyChange: 'myChange',
+        onMyFocus: 'myFocus',
+        onMyBlur: 'myBlur'
+    } as MyRangeEvents,
+    defineCustomElement: defineMyRange
 });

--- a/packages/example-project/next-app/src/app/components.server.ts
+++ b/packages/example-project/next-app/src/app/components.server.ts
@@ -39,6 +39,21 @@ export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = 
     })
     : /*@__PURE__*/ createSSRComponent<MyButtonElement, MyButtonEvents>({
         tagName: 'my-button',
+        properties: {
+            color: 'color',
+            buttonType: 'button-type',
+            disabled: 'disabled',
+            expand: 'expand',
+            fill: 'fill',
+            download: 'download',
+            href: 'href',
+            rel: 'rel',
+            shape: 'shape',
+            size: 'size',
+            strong: 'strong',
+            target: 'target',
+            type: 'type'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -62,6 +77,14 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
     })
     : /*@__PURE__*/ createSSRComponent<MyCheckboxElement, MyCheckboxEvents>({
         tagName: 'my-checkbox',
+        properties: {
+            color: 'color',
+            name: 'name',
+            checked: 'checked',
+            indeterminate: 'indeterminate',
+            disabled: 'disabled',
+            value: 'value'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -77,6 +100,13 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     })
     : /*@__PURE__*/ createSSRComponent<MyComponentElement, MyComponentEvents>({
         tagName: 'my-component',
+        properties: {
+            first: 'first',
+            middle: 'middle',
+            last: 'last',
+            age: 'age',
+            favoriteKidName: 'favorite-kid-name'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -102,6 +132,34 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = typ
     })
     : /*@__PURE__*/ createSSRComponent<MyInputElement, MyInputEvents>({
         tagName: 'my-input',
+        properties: {
+            color: 'color',
+            accept: 'accept',
+            autocapitalize: 'autocapitalize',
+            autocomplete: 'autocomplete',
+            autocorrect: 'autocorrect',
+            autofocus: 'autofocus',
+            clearInput: 'clear-input',
+            clearOnEdit: 'clear-on-edit',
+            disabled: 'disabled',
+            enterkeyhint: 'enterkeyhint',
+            inputmode: 'inputmode',
+            max: 'max',
+            maxlength: 'maxlength',
+            min: 'min',
+            minlength: 'minlength',
+            multiple: 'multiple',
+            name: 'name',
+            pattern: 'pattern',
+            placeholder: 'placeholder',
+            readonly: 'readonly',
+            required: 'required',
+            spellcheck: 'spellcheck',
+            step: 'step',
+            size: 'size',
+            type: 'type',
+            value: 'value'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -127,6 +185,16 @@ export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents>
     })
     : /*@__PURE__*/ createSSRComponent<MyPopoverElement, MyPopoverEvents>({
         tagName: 'my-popover',
+        properties: {
+            component: 'component',
+            keyboardClose: 'keyboard-close',
+            cssClass: 'css-class',
+            backdropDismiss: 'backdrop-dismiss',
+            event: 'event',
+            showBackdrop: 'show-backdrop',
+            translucent: 'translucent',
+            animated: 'animated'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -150,6 +218,12 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = typ
     })
     : /*@__PURE__*/ createSSRComponent<MyRadioElement, MyRadioEvents>({
         tagName: 'my-radio',
+        properties: {
+            color: 'color',
+            name: 'name',
+            disabled: 'disabled',
+            value: 'value'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -165,6 +239,11 @@ export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGro
     })
     : /*@__PURE__*/ createSSRComponent<MyRadioGroupElement, MyRadioGroupEvents>({
         tagName: 'my-radio-group',
+        properties: {
+            allowEmptySelection: 'allow-empty-selection',
+            name: 'name',
+            value: 'value'
+        },
         hydrateModule: import('component-library/hydrate')
     });
 
@@ -188,5 +267,19 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = typ
     })
     : /*@__PURE__*/ createSSRComponent<MyRangeElement, MyRangeEvents>({
         tagName: 'my-range',
+        properties: {
+            color: 'color',
+            debounce: 'debounce',
+            name: 'name',
+            dualKnobs: 'dual-knobs',
+            min: 'min',
+            max: 'max',
+            pin: 'pin',
+            snaps: 'snaps',
+            step: 'step',
+            ticks: 'ticks',
+            disabled: 'disabled',
+            value: 'value'
+        },
         hydrateModule: import('component-library/hydrate')
     });

--- a/packages/example-project/next-app/test/specs/test.e2e.mts
+++ b/packages/example-project/next-app/test/specs/test.e2e.mts
@@ -36,4 +36,10 @@ describe('Stencil NextJS Integration', () => {
   it('should transform camelCase into kebab-case', async () => {
     await expect($('my-component[favorite-kid-name="foobar"]')).toBePresent();
   });
+
+  // Issue https://github.com/ionic-team/stencil-ds-output-targets/issues/470
+  it('should render shadowroot button link only once', async () => {
+    const shadowButtons = await $('my-button').shadow$$('a');
+    await expect(shadowButtons.length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

ATM a nested web component leads to a duplication of the root component within the shadow-root of the root component.

Issue URL: https://github.com/ionic-team/stencil-ds-output-targets/issues/470

## What is the new behavior?

This pull request adds a quasi unique id to components which are rendered with `renderToString` in `createComponentForServerSideRendering` so that Stencil can correctly hydrate them client-side.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I know that this is not the prettiest and sustainable solution, but it solves the problem temporarily and we could use the package in our project until there is a better solution.
