### PR TITLE
fix: module points to es2015-build

### DIFF
--- a/packages/example-project/component-library-angular/package.json
+++ b/packages/example-project/component-library-angular/package.json
@@ -23,7 +23,7 @@
     "tsc": "tsc -p .",
     "validate": "pnpm i && pnpm run lint && pnpm run test && pnpm run build"
   },
-  "module": "dist/fesm5.js",
+  "module": "dist/fesm2015.js",
   "main": "dist/fesm5.js",
   "types": "dist/core.d.ts",
   "files": [


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

The "module" field in the package.json of the Angular example project points to the fesm5 build.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The "module" field in the package.json of the Angular example project points to the fesm2015 build, as described in https://esbuild.github.io/api/#main-fields.

Without it Angular will use the fesm5 build when it could have used fesm2015.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

If a project is already using the "module"-build it should support es2015.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I found this issue while investigating why my Angular project, which uses standalone Stencil Angular output, was failing to tree shake unused components. To resolve it, I not only had to modify the module field but also set `"sideEffects": false` to enable tree shaking.

