### PR TITLE
repo: use new output nomenclature for dev builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -39,7 +39,7 @@ jobs:
           HUSKY_SKIP_HOOKS=1 lerna publish 0.0.1-dev.$(echo "${{ env.TIMESTAMP }}").$(echo "${{ env.HASH }}") --no-verify-access --yes --force-publish='*' --dist-tag dev --no-git-tag-version --no-push --exact
         shell: bash
       - id: dev-build
-        run: echo "::set-output name=version::0.0.1-dev.$(echo "${{ env.TIMESTAMP }}").$(echo "${{ env.HASH }}")"
+        run: echo "version=0.0.1-dev.$(echo "${{ env.TIMESTAMP }}").$(echo "${{ env.HASH }}")" >> $GITHUB_OUTPUT
   get-build:
     name: Get your dev build!
     runs-on: ubuntu-latest


### PR DESCRIPTION
original authored by @rwaskiewicz in #338

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Our tech debt burndown job uses the `set-output` syntax. `set-output` was deprecated on 2022.10.11, in
favor of a new syntax - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. starting 2023.05.31, `set-output` is intended to be disabled.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates all workflows using the "old" output nomenclature to
use the newer variant.  applying this commit will allow the tech debt burndown to continue to function as
expected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

