### PR TITLE
Publish: @stencil/angular-output-target v0.10.0, @stencil/react-output-target v0.7.4

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/angular-output-target",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Angular output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/react-output-target",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "React output target for @stencil/core components.",
   "main": "./dist/react-output-target.js",
   "module": "./dist/react-output-target.js",


### PR DESCRIPTION
This patch bumps versions for:

- `@stencil/angular-output-target` to `v0.10.0`
- `@stencil/react-output-target` to `v0.7.4`

# Changes

Some general project changes include:

## React Output Target

- #508 (https://github.com/ionic-team/stencil-ds-output-targets/commit/a11a8d80d5e996fc59ebb7ab025a606660a9a3ca)

## Angular Output Target

- #514 (https://github.com/ionic-team/stencil-ds-output-targets/commit/11470780a1f02e970a405eb4b229cda0ee1e8270)
- #497 (https://github.com/ionic-team/stencil-ds-output-targets/commit/756a4665f49723e6bccf962f01ceaf54eae99bdf)
