### PR TITLE
fix(angular): 2-way data-binding for inlined Inputs

### DIFF
--- a/example-project/component-library-angular/src/directives/proxies.ts
+++ b/example-project/component-library-angular/src/directives/proxies.ts
@@ -18,7 +18,7 @@ import { Components } from 'component-library';
   inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type'],
 })
 export class MyButton {
-  protected el: HTMLElement;
+  protected el: HTMLMyButtonElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -50,7 +50,7 @@ export declare interface MyButton extends Components.MyButton {
   inputs: ['checked', 'color', 'disabled', 'indeterminate', 'mode', 'name', 'value'],
 })
 export class MyCheckbox {
-  protected el: HTMLElement;
+  protected el: HTMLMyCheckboxElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -88,7 +88,7 @@ export declare interface MyCheckbox extends Components.MyCheckbox {
   inputs: ['age', 'favoriteKidName', 'first', 'kidsNames', 'last', 'middle'],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -117,7 +117,7 @@ export declare interface MyComponent extends Components.MyComponent {
   inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'],
 })
 export class MyInput {
-  protected el: HTMLElement;
+  protected el: HTMLMyInputElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -160,7 +160,7 @@ export declare interface MyInput extends Components.MyInput {
   inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
 })
 export class MyPopover {
-  protected el: HTMLElement;
+  protected el: HTMLMyPopoverElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -202,7 +202,7 @@ export declare interface MyPopover extends Components.MyPopover {
   inputs: ['color', 'disabled', 'mode', 'name', 'value'],
 })
 export class MyRadio {
-  protected el: HTMLElement;
+  protected el: HTMLMyRadioElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -238,7 +238,7 @@ export declare interface MyRadio extends Components.MyRadio {
   inputs: ['allowEmptySelection', 'name', 'value'],
 })
 export class MyRadioGroup {
-  protected el: HTMLElement;
+  protected el: HTMLMyRadioGroupElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -268,7 +268,7 @@ export declare interface MyRadioGroup extends Components.MyRadioGroup {
   inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value'],
 })
 export class MyRange {
-  protected el: HTMLElement;
+  protected el: HTMLMyRangeElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;

--- a/packages/angular/tests/generate-angular-component.test.ts
+++ b/packages/angular/tests/generate-angular-component.test.ts
@@ -17,7 +17,7 @@ describe('createAngularComponentDefinition()', () => {
   inputs: [],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -38,7 +38,7 @@ export class MyComponent {
   inputs: ['my-input', 'my-other-input'],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -65,7 +65,7 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -88,7 +88,7 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -112,7 +112,7 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -135,7 +135,7 @@ export class MyComponent {
   inputs: ['my-input', 'my-other-input'],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -162,7 +162,7 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -186,7 +186,7 @@ export class MyComponent {
   inputs: [],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -209,7 +209,7 @@ export class MyComponent {
   standalone: true
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -241,11 +241,11 @@ export class MyComponent {
   inputs: ['myMember'],
 })
 export class MyComponent {
-  protected el: HTMLElement;
+  protected el: HTMLMyComponentElement;
     /**
    * This is a jsDoc for myMember @deprecated use v2 of this API
    */
-  myMember: Components.MyComponent['myMember'];
+  set myMember(_: Components.MyComponent['myMember']) {};
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?
When using the new `inlineProperties` configuration option, properties only update correctly when they are used unbounded(`<my-component prop="value" />`), on the angular side. Bound(`<my-component [prop]="componentProperty" />`) properties are not synced correctly.

## What is the new behavior?

Properties work correctly, no matter if they are used bound or unbounded.

## Does this introduce a breaking change?

- [x] No

## General Information

PR #497 by @kristilw introduced a long awaited fix for Angular, allowing the Angular Language Server to pick up the types of inputs correctly.

The change works correctly on the Typescript side, as well as at runtime, if the input properties are unbound. However, if they are bound the Angular Compiler does _something_ that prevents the binding to work at all (at runtime), even though the Decorator establishing the getter and setter to pass the value along to the Web Component underneath is run correctly.

This is caused (for some reason) by the property being declared on the class itself, after compilation, like this:

```typescript
export let MyComponent = class MyComponent {
    z;
    el;
    prop; // <-- THIS IS THE PROBLEM
    constructor(c, r, z) {
        this.z = z;
        c.detach();
        this.el = r.nativeElement;
    }
    static ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.NgZone)); };
    static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: MyComponent, selectors: [["my-component"]], inputs: { prop: "prop" }, ngContentSelectors: _c0, decls: 1, vars: 0, template: function MyComponent_Template(rf, ctx) { if (rf & 1) {
            i0.ɵɵprojectionDef();
            i0.ɵɵprojection(0);
        } }, encapsulation: 2, changeDetection: 0 });
};
```

However, in order for typescript to create the type in such a way that the (badly implemented) Angular Language Service can pick up the types correctly, we need to declare them on the class.

The solution is to inline the getter and setter for the inputs directly, allowing Angular to pick up the type correctly, and the internal binding to the web component to work correctly as well.

This PR also changes the type of the `el` property, so that it reflects the accurate Web Component type, instead of the generic `HTMLElement`.
