### PR TITLE
feat: Add a node-specific entry point for the React package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,6 +77,9 @@
       "browser": {
         "default": "./dist/react.js"
       },
+      "node": {
+        "default": "./dist/react.cjs"
+      },
       "default": "./dist/react.js"
     },
     "./ssr": {


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The package.json does not explicitly define a Node.js-specific entry point. As a result, consumers of the package in Node.js environments rely on the default entry point, which may lead to incorrect module resolution or format issues when used in Node.js.

## What is the new behavior?

Add a node-specific entry point for the React package. This ensures that the correct module format is used when the package is required in a Node.js environment.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
