### PR TITLE
Publish: @stencil/angular-output-target v0.10.1, @stencil/react-output-target v0.8.0, @stencil/vue-output-target v0.9.1

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/angular-output-target",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Angular output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/react-output-target",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "React output target for @stencil/core components.",
   "main": "./dist/react-output-target.js",
   "module": "./dist/react-output-target.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Vue output target for @stencil/core components.",
   "author": "Ionic Team",
   "homepage": "https://stenciljs.com/",


### PR DESCRIPTION
This patch bumps versions for:

- `@stencil/angular-output-target` to `v0.10.1`
- `@stencil/react-output-target` to `v0.8.0`

# Changes

Some general project changes include:

## React Output Target

- #540 (https://github.com/ionic-team/stencil-ds-output-targets/commit/528ba3abd80ae0b47877af5d0ed11c88b50ebe48)
- #549 (https://github.com/ionic-team/stencil-ds-output-targets/commit/aa405fab2763316a471b5f997eab31aa1be73d0a)
- #562 (https://github.com/ionic-team/stencil-ds-output-targets/commit/1b8fb076daef56fcd54034936d2f6bc17c53cda0)

## Angular Output Target

- #543 (https://github.com/ionic-team/stencil-ds-output-targets/commit/e9c6056c276a3a4a924585dae86458311187d4f3)
- #533 (https://github.com/ionic-team/stencil-ds-output-targets/commit/61a3975d9111dadf5f6dab0553c71693fb912577)

## Vue Output Target

- #566 (https://github.com/ionic-team/stencil-ds-output-targets/commit/1af50e3cf963314fcd0a87072d42bf99b15f0143)

# 🙏 

Thank you @dwirz, @baumgm94, @alexandertrefz and @aesteves60 for the contribution!