### PR TITLE
fix(react): hide SSR rendering error

### DIFF
--- a/packages/react/src/react/ssr.tsx
+++ b/packages/react/src/react/ssr.tsx
@@ -145,12 +145,14 @@ export const createComponentForServerSideRendering = <I extends HTMLElement, E e
       /**
        * if rendering the light DOM fails, we log a warning and continue to render the component
        */
-      const error = err instanceof Error ? err : new Error('Unknown error');
-      console.warn(
-        `${LOG_PREFIX} Failed to serialize light DOM for ${toSerialize.slice(0, -1)} />: ${
-          error.message
-        } - this may impact the hydration of the component`
-      );
+      if (process.env.STENCIL_SSR_DEBUG) {
+        const error = err instanceof Error ? err : new Error('Unknown error');
+        console.warn(
+          `${LOG_PREFIX} Failed to serialize light DOM for ${toSerialize.slice(0, -1)} />: ${
+            error.message
+          } - this may impact the hydration of the component`
+        );
+      }
     }
 
     const toSerializeWithChildren = `${toSerialize}${serializedChildren}</${options.tagName}>`;


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There are cases where we can't resolve the children of React components during the SSR process. In most cases this can be ignored as Next.js properly resolves the children individually. Right now we print the warning to stdout which may confuse folks when running e.g. tests with Playwright.

## What is the new behavior?

Disable the logging and put it behind a flag.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

n/a
