### PR TITLE
Publish: @stencil/angular-output-target v0.10.2, @stencil/react-outpu…

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/angular-output-target",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Angular output target for @stencil/core components.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/react-output-target",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "React output target for @stencil/core components.",
   "main": "./dist/react-output-target.js",
   "module": "./dist/react-output-target.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Vue output target for @stencil/core components.",
   "author": "Ionic Team",
   "homepage": "https://stenciljs.com/",


### PR DESCRIPTION
This patch bumps versions for:

- `@stencil/angular-output-target` to `v0.10.2`
- `@stencil/react-output-target` to `v0.8.1`
- `@stencil/vue-output-target` to `v0.9.2`

# Changes

Some general project changes include:

## React Output Target

- https://github.com/ionic-team/stencil-ds-output-targets/pull/573

## Angular Output Target

- https://github.com/ionic-team/stencil-ds-output-targets/pull/575

## Vue Output Target

- https://github.com/ionic-team/stencil-ds-output-targets/pull/574