### PR TITLE
fix(react): improve resolving component types

### DIFF
--- a/example-project/component-library-angular/src/directives/proxies.ts
+++ b/example-project/component-library-angular/src/directives/proxies.ts
@@ -155,6 +155,48 @@ export declare interface MyInput extends Components.MyInput {
 
 
 @ProxyCmp({
+})
+@Component({
+  selector: 'my-list',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [],
+})
+export class MyList {
+  protected el: HTMLMyListElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface MyList extends Components.MyList {}
+
+
+@ProxyCmp({
+})
+@Component({
+  selector: 'my-list-item',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [],
+})
+export class MyListItem {
+  protected el: HTMLMyListItemElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface MyListItem extends Components.MyListItem {}
+
+
+@ProxyCmp({
   inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
   methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
@@ -299,5 +341,48 @@ export declare interface MyRange extends Components.MyRange {
    */
   myBlur: EventEmitter<CustomEvent<void>>;
 }
+
+
+@ProxyCmp({
+})
+@Component({
+  selector: 'my-toggle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [],
+})
+export class MyToggle {
+  protected el: HTMLMyToggleElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface MyToggle extends Components.MyToggle {}
+
+
+@ProxyCmp({
+  inputs: ['visible']
+})
+@Component({
+  selector: 'my-toggle-content',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['visible'],
+})
+export class MyToggleContent {
+  protected el: HTMLMyToggleContentElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface MyToggleContent extends Components.MyToggleContent {}
 
 

--- a/example-project/component-library-react/src/components.ts
+++ b/example-project/component-library-react/src/components.ts
@@ -14,10 +14,14 @@ import { MyButton as MyButtonElement, defineCustomElement as defineMyButton } fr
 import { MyCheckbox as MyCheckboxElement, defineCustomElement as defineMyCheckbox } from "component-library/components/my-checkbox.js";
 import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "component-library/components/my-component.js";
 import { MyInput as MyInputElement, defineCustomElement as defineMyInput } from "component-library/components/my-input.js";
+import { MyListItem as MyListItemElement, defineCustomElement as defineMyListItem } from "component-library/components/my-list-item.js";
+import { MyList as MyListElement, defineCustomElement as defineMyList } from "component-library/components/my-list.js";
 import { MyPopover as MyPopoverElement, defineCustomElement as defineMyPopover } from "component-library/components/my-popover.js";
 import { MyRadioGroup as MyRadioGroupElement, defineCustomElement as defineMyRadioGroup } from "component-library/components/my-radio-group.js";
 import { MyRadio as MyRadioElement, defineCustomElement as defineMyRadio } from "component-library/components/my-radio.js";
 import { MyRange as MyRangeElement, defineCustomElement as defineMyRange } from "component-library/components/my-range.js";
+import { MyToggleContent as MyToggleContentElement, defineCustomElement as defineMyToggleContent } from "component-library/components/my-toggle-content.js";
+import { MyToggle as MyToggleElement, defineCustomElement as defineMyToggle } from "component-library/components/my-toggle.js";
 import React from 'react';
 
 type MyButtonEvents = {
@@ -94,6 +98,28 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@
     defineCustomElement: defineMyInput
 });
 
+type MyListEvents = NonNullable<unknown>;
+
+export const MyList: StencilReactComponent<MyListElement, MyListEvents> = /*@__PURE__*/ createComponent<MyListElement, MyListEvents>({
+    tagName: 'my-list',
+    elementClass: MyListElement,
+    // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+    react: React,
+    events: {} as MyListEvents,
+    defineCustomElement: defineMyList
+});
+
+type MyListItemEvents = NonNullable<unknown>;
+
+export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEvents> = /*@__PURE__*/ createComponent<MyListItemElement, MyListItemEvents>({
+    tagName: 'my-list-item',
+    elementClass: MyListItemElement,
+    // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+    react: React,
+    events: {} as MyListItemEvents,
+    defineCustomElement: defineMyListItem
+});
+
 type MyPopoverEvents = {
     onMyPopoverDidPresent: EventName<CustomEvent<void>>,
     onMyPopoverWillPresent: EventName<CustomEvent<void>>,
@@ -162,4 +188,26 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@
         onMyBlur: 'myBlur'
     } as MyRangeEvents,
     defineCustomElement: defineMyRange
+});
+
+type MyToggleEvents = NonNullable<unknown>;
+
+export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents> = /*@__PURE__*/ createComponent<MyToggleElement, MyToggleEvents>({
+    tagName: 'my-toggle',
+    elementClass: MyToggleElement,
+    // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+    react: React,
+    events: {} as MyToggleEvents,
+    defineCustomElement: defineMyToggle
+});
+
+type MyToggleContentEvents = NonNullable<unknown>;
+
+export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyToggleContentEvents> = /*@__PURE__*/ createComponent<MyToggleContentElement, MyToggleContentEvents>({
+    tagName: 'my-toggle-content',
+    elementClass: MyToggleContentElement,
+    // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+    react: React,
+    events: {} as MyToggleContentEvents,
+    defineCustomElement: defineMyToggleContent
 });

--- a/example-project/component-library-vue/src/index.ts
+++ b/example-project/component-library-vue/src/index.ts
@@ -9,10 +9,14 @@ import { defineCustomElement as defineMyButton } from 'component-library/compone
 import { defineCustomElement as defineMyCheckbox } from 'component-library/components/my-checkbox.js';
 import { defineCustomElement as defineMyComponent } from 'component-library/components/my-component.js';
 import { defineCustomElement as defineMyInput } from 'component-library/components/my-input.js';
+import { defineCustomElement as defineMyList } from 'component-library/components/my-list.js';
+import { defineCustomElement as defineMyListItem } from 'component-library/components/my-list-item.js';
 import { defineCustomElement as defineMyPopover } from 'component-library/components/my-popover.js';
 import { defineCustomElement as defineMyRadio } from 'component-library/components/my-radio.js';
 import { defineCustomElement as defineMyRadioGroup } from 'component-library/components/my-radio-group.js';
 import { defineCustomElement as defineMyRange } from 'component-library/components/my-range.js';
+import { defineCustomElement as defineMyToggle } from 'component-library/components/my-toggle.js';
+import { defineCustomElement as defineMyToggleContent } from 'component-library/components/my-toggle-content.js';
 
 
 export const MyButton = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyButton>('my-button', defineMyButton, [
@@ -193,6 +197,24 @@ export const MyInput = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyI
 });
 
 
+export const MyList = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyList>('my-list', defineMyList) : defineStencilSSRComponent({
+  tagName: 'my-list',
+  hydrateModule: import('component-library/hydrate'),
+  props: {
+    
+  }
+});
+
+
+export const MyListItem = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyListItem>('my-list-item', defineMyListItem) : defineStencilSSRComponent({
+  tagName: 'my-list-item',
+  hydrateModule: import('component-library/hydrate'),
+  props: {
+    
+  }
+});
+
+
 export const MyPopover = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyPopover>('my-popover', defineMyPopover, [
   'component',
   'componentProps',
@@ -322,6 +344,26 @@ export const MyRange = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyR
     'onMyStyle': [Function],
     'onMyFocus': [Function],
     'onMyBlur': [Function]
+  }
+});
+
+
+export const MyToggle = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyToggle>('my-toggle', defineMyToggle) : defineStencilSSRComponent({
+  tagName: 'my-toggle',
+  hydrateModule: import('component-library/hydrate'),
+  props: {
+    
+  }
+});
+
+
+export const MyToggleContent = /*@__PURE__*/ globalThis.window ? defineContainer<JSX.MyToggleContent>('my-toggle-content', defineMyToggleContent, [
+  'visible'
+]) : defineStencilSSRComponent({
+  tagName: 'my-toggle-content',
+  hydrateModule: import('component-library/hydrate'),
+  props: {
+    'visible': [Boolean, "visible"]
   }
 });
 

--- a/example-project/component-library/src/components.d.ts
+++ b/example-project/component-library/src/components.d.ts
@@ -250,6 +250,10 @@ export namespace Components {
          */
         "value"?: string | number | null;
     }
+    interface MyList {
+    }
+    interface MyListItem {
+    }
     interface MyPopover {
         /**
           * If `true`, the popover will animate.
@@ -400,6 +404,11 @@ export namespace Components {
          */
         "value": RangeValue;
     }
+    interface MyToggle {
+    }
+    interface MyToggleContent {
+        "visible": boolean;
+    }
 }
 export interface MyButtonCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -510,6 +519,18 @@ declare global {
         prototype: HTMLMyInputElement;
         new (): HTMLMyInputElement;
     };
+    interface HTMLMyListElement extends Components.MyList, HTMLStencilElement {
+    }
+    var HTMLMyListElement: {
+        prototype: HTMLMyListElement;
+        new (): HTMLMyListElement;
+    };
+    interface HTMLMyListItemElement extends Components.MyListItem, HTMLStencilElement {
+    }
+    var HTMLMyListItemElement: {
+        prototype: HTMLMyListItemElement;
+        new (): HTMLMyListItemElement;
+    };
     interface HTMLMyPopoverElementEventMap {
         "myPopoverDidPresent": void;
         "myPopoverWillPresent": void;
@@ -587,15 +608,31 @@ declare global {
         prototype: HTMLMyRangeElement;
         new (): HTMLMyRangeElement;
     };
+    interface HTMLMyToggleElement extends Components.MyToggle, HTMLStencilElement {
+    }
+    var HTMLMyToggleElement: {
+        prototype: HTMLMyToggleElement;
+        new (): HTMLMyToggleElement;
+    };
+    interface HTMLMyToggleContentElement extends Components.MyToggleContent, HTMLStencilElement {
+    }
+    var HTMLMyToggleContentElement: {
+        prototype: HTMLMyToggleContentElement;
+        new (): HTMLMyToggleContentElement;
+    };
     interface HTMLElementTagNameMap {
         "my-button": HTMLMyButtonElement;
         "my-checkbox": HTMLMyCheckboxElement;
         "my-component": HTMLMyComponentElement;
         "my-input": HTMLMyInputElement;
+        "my-list": HTMLMyListElement;
+        "my-list-item": HTMLMyListItemElement;
         "my-popover": HTMLMyPopoverElement;
         "my-radio": HTMLMyRadioElement;
         "my-radio-group": HTMLMyRadioGroupElement;
         "my-range": HTMLMyRangeElement;
+        "my-toggle": HTMLMyToggleElement;
+        "my-toggle-content": HTMLMyToggleContentElement;
     }
 }
 declare namespace LocalJSX {
@@ -871,6 +908,10 @@ declare namespace LocalJSX {
          */
         "value"?: string | number | null;
     }
+    interface MyList {
+    }
+    interface MyListItem {
+    }
     interface MyPopover {
         /**
           * If `true`, the popover will animate.
@@ -1055,15 +1096,24 @@ declare namespace LocalJSX {
          */
         "value"?: RangeValue;
     }
+    interface MyToggle {
+    }
+    interface MyToggleContent {
+        "visible"?: boolean;
+    }
     interface IntrinsicElements {
         "my-button": MyButton;
         "my-checkbox": MyCheckbox;
         "my-component": MyComponent;
         "my-input": MyInput;
+        "my-list": MyList;
+        "my-list-item": MyListItem;
         "my-popover": MyPopover;
         "my-radio": MyRadio;
         "my-radio-group": MyRadioGroup;
         "my-range": MyRange;
+        "my-toggle": MyToggle;
+        "my-toggle-content": MyToggleContent;
     }
 }
 export { LocalJSX as JSX };
@@ -1074,10 +1124,14 @@ declare module "@stencil/core" {
             "my-checkbox": LocalJSX.MyCheckbox & JSXBase.HTMLAttributes<HTMLMyCheckboxElement>;
             "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             "my-input": LocalJSX.MyInput & JSXBase.HTMLAttributes<HTMLMyInputElement>;
+            "my-list": LocalJSX.MyList & JSXBase.HTMLAttributes<HTMLMyListElement>;
+            "my-list-item": LocalJSX.MyListItem & JSXBase.HTMLAttributes<HTMLMyListItemElement>;
             "my-popover": LocalJSX.MyPopover & JSXBase.HTMLAttributes<HTMLMyPopoverElement>;
             "my-radio": LocalJSX.MyRadio & JSXBase.HTMLAttributes<HTMLMyRadioElement>;
             "my-radio-group": LocalJSX.MyRadioGroup & JSXBase.HTMLAttributes<HTMLMyRadioGroupElement>;
             "my-range": LocalJSX.MyRange & JSXBase.HTMLAttributes<HTMLMyRangeElement>;
+            "my-toggle": LocalJSX.MyToggle & JSXBase.HTMLAttributes<HTMLMyToggleElement>;
+            "my-toggle-content": LocalJSX.MyToggleContent & JSXBase.HTMLAttributes<HTMLMyToggleContentElement>;
         }
     }
 }

--- a/example-project/component-library/src/components/my-list-item/my-list-item.tsx
+++ b/example-project/component-library/src/components/my-list-item/my-list-item.tsx
@@ -1,0 +1,15 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'my-list-item',
+  shadow: true,
+})
+export class MyListItem {
+  render() {
+    return (
+      <li>
+        <slot></slot>
+      </li>
+    );
+  }
+}

--- a/example-project/component-library/src/components/my-list-item/readme.md
+++ b/example-project/component-library/src/components/my-list-item/readme.md
@@ -1,0 +1,10 @@
+# my-list-item
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/example-project/component-library/src/components/my-list/my-list.tsx
+++ b/example-project/component-library/src/components/my-list/my-list.tsx
@@ -1,0 +1,15 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'my-list',
+  shadow: true,
+})
+export class MyList {
+  render() {
+    return (
+      <ul>
+        <slot></slot>
+      </ul>
+    );
+  }
+}

--- a/example-project/component-library/src/components/my-list/readme.md
+++ b/example-project/component-library/src/components/my-list/readme.md
@@ -1,0 +1,10 @@
+# my-list
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/example-project/component-library/src/components/my-toggle-content/my-toggle-content.tsx
+++ b/example-project/component-library/src/components/my-toggle-content/my-toggle-content.tsx
@@ -1,0 +1,21 @@
+import { Component, Fragment, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'my-toggle-content',
+  shadow: true,
+})
+export class MyToggleContent {
+  @Prop() visible: boolean;
+
+  render() {
+    return (
+      this.visible && (
+        <Fragment>
+          <div>
+            <slot></slot>
+          </div>
+        </Fragment>
+      )
+    );
+  }
+}

--- a/example-project/component-library/src/components/my-toggle-content/readme.md
+++ b/example-project/component-library/src/components/my-toggle-content/readme.md
@@ -1,0 +1,30 @@
+# my-slot-component
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type      | Default     |
+| --------- | --------- | ----------- | --------- | ----------- |
+| `visible` | `visible` |             | `boolean` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [my-toggle](../my-toggle)
+
+### Graph
+```mermaid
+graph TD;
+  my-toggle --> my-toggle-content
+  style my-toggle-content fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/example-project/component-library/src/components/my-toggle/my-toggle.tsx
+++ b/example-project/component-library/src/components/my-toggle/my-toggle.tsx
@@ -1,0 +1,20 @@
+import { Component, Fragment, h, State } from '@stencil/core';
+
+@Component({
+  tag: 'my-toggle',
+  shadow: true,
+})
+export class MyToggle {
+  @State() showContent = false;
+
+  render() {
+    return (
+      <Fragment>
+        <button onClick={() => (this.showContent = !this.showContent)}>Open Modal</button>
+        <my-toggle-content visible={this.showContent}>
+          <slot></slot>
+        </my-toggle-content>
+      </Fragment>
+    );
+  }
+}

--- a/example-project/component-library/src/components/my-toggle/readme.md
+++ b/example-project/component-library/src/components/my-toggle/readme.md
@@ -1,0 +1,23 @@
+# my-slot-component
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Dependencies
+
+### Depends on
+
+- [my-toggle-content](../my-toggle-content)
+
+### Graph
+```mermaid
+graph TD;
+  my-toggle --> my-toggle-content
+  style my-toggle fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/example-project/next-app/src/app/LazyComponent/LazyComponent.tsx
+++ b/example-project/next-app/src/app/LazyComponent/LazyComponent.tsx
@@ -1,0 +1,7 @@
+import { lazy } from 'react';
+
+export const LazyComponent = lazy(() =>
+  import('./LazyLoadedComponent').then((module) => ({
+    default: module.LazyLoadedComponent,
+  }))
+);

--- a/example-project/next-app/src/app/LazyComponent/LazyLoadedComponent.tsx
+++ b/example-project/next-app/src/app/LazyComponent/LazyLoadedComponent.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useContext, useState } from 'react';
+import { ThemeContext } from '../ThemeContext/ThemeContext';
+
+export const LazyLoadedComponent = () => {
+  const [state, setState] = useState(0);
+  const theme = useContext(ThemeContext);
+
+  return (
+    <div style={{ border: '1px red solid', padding: '1rem', margin: '1rem', borderRadius: '0.5rem' }}>
+      <p style={{ marginBottom: '0.5rem' }}>LazyLoadedComponent with theme: {theme}</p>
+      <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+        <button
+          style={{ border: '1px solid black', padding: '0.5rem', borderRadius: '0.5rem' }}
+          onClick={() => setState(state - 1)}
+        >
+          -
+        </button>
+        <span>{state}</span>
+        <button
+          style={{ border: '1px solid black', padding: '0.5rem', borderRadius: '0.5rem' }}
+          onClick={() => setState(state + 1)}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/example-project/next-app/src/app/List/List.tsx
+++ b/example-project/next-app/src/app/List/List.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { MyList, MyListItem } from '../components.server';
+import { LazyComponent } from '../LazyComponent/LazyComponent';
+import { ThemeContext } from '../ThemeContext/ThemeContext';
+
+export const List = () => {
+  const theme = 'light';
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <LazyComponent />
+      <MyList>
+        <MyListItem>Item 1</MyListItem>
+        <MyListItem>Item 2</MyListItem>
+        <MyListItem>Item 3</MyListItem>
+      </MyList>
+    </ThemeContext.Provider>
+  );
+};

--- a/example-project/next-app/src/app/PureReactComponent/PureReactComponent.tsx
+++ b/example-project/next-app/src/app/PureReactComponent/PureReactComponent.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useState } from 'react';
+
+export const PureReactComponent = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div style={{ padding: '1rem', border: '1px solid black', borderRadius: '0.5rem', margin: '1rem' }}>
+      <p style={{ marginBottom: '0.5rem' }}>Pure React Component</p>
+      <button
+        style={{ border: '1px solid black', padding: '0.5rem', borderRadius: '0.5rem' }}
+        onClick={() => setCount(count + 1)}
+      >
+        Click me (Clicked: {count})
+      </button>
+    </div>
+  );
+};

--- a/example-project/next-app/src/app/ThemeContext/ThemeContext.tsx
+++ b/example-project/next-app/src/app/ThemeContext/ThemeContext.tsx
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const ThemeContext = createContext('light');

--- a/example-project/next-app/src/app/ToggleableContent/ToggleableContent.tsx
+++ b/example-project/next-app/src/app/ToggleableContent/ToggleableContent.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { MyToggle } from '../components.server';
+import { List } from '../List/List';
+import { PureReactComponent } from '../PureReactComponent/PureReactComponent';
+
+export const ToggleableContent = () => {
+  return (
+    <MyToggle>
+      <PureReactComponent />
+      <List />
+    </MyToggle>
+  );
+};

--- a/example-project/next-app/src/app/components.server.ts
+++ b/example-project/next-app/src/app/components.server.ts
@@ -15,10 +15,14 @@ import { MyButton as MyButtonElement, defineCustomElement as defineMyButton } fr
 import { MyCheckbox as MyCheckboxElement, defineCustomElement as defineMyCheckbox } from "component-library/components/my-checkbox.js";
 import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "component-library/components/my-component.js";
 import { MyInput as MyInputElement, defineCustomElement as defineMyInput } from "component-library/components/my-input.js";
+import { MyListItem as MyListItemElement, defineCustomElement as defineMyListItem } from "component-library/components/my-list-item.js";
+import { MyList as MyListElement, defineCustomElement as defineMyList } from "component-library/components/my-list.js";
 import { MyPopover as MyPopoverElement, defineCustomElement as defineMyPopover } from "component-library/components/my-popover.js";
 import { MyRadioGroup as MyRadioGroupElement, defineCustomElement as defineMyRadioGroup } from "component-library/components/my-radio-group.js";
 import { MyRadio as MyRadioElement, defineCustomElement as defineMyRadio } from "component-library/components/my-radio.js";
 import { MyRange as MyRangeElement, defineCustomElement as defineMyRange } from "component-library/components/my-range.js";
+import { MyToggleContent as MyToggleContentElement, defineCustomElement as defineMyToggleContent } from "component-library/components/my-toggle-content.js";
+import { MyToggle as MyToggleElement, defineCustomElement as defineMyToggle } from "component-library/components/my-toggle.js";
 import React from 'react';
 
 type MyButtonEvents = {
@@ -173,6 +177,40 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = typ
         hydrateModule: import('component-library/hydrate')
     });
 
+type MyListEvents = NonNullable<unknown>;
+
+export const MyList: StencilReactComponent<MyListElement, MyListEvents> = typeof window !== 'undefined'
+    ? /*@__PURE__*/ createComponent<MyListElement, MyListEvents>({
+        tagName: 'my-list',
+        elementClass: MyListElement,
+        // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+        react: React,
+        events: {} as MyListEvents,
+        defineCustomElement: defineMyList
+    })
+    : /*@__PURE__*/ createSSRComponent<MyListElement, MyListEvents>({
+        tagName: 'my-list',
+        properties: {},
+        hydrateModule: import('component-library/hydrate')
+    });
+
+type MyListItemEvents = NonNullable<unknown>;
+
+export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEvents> = typeof window !== 'undefined'
+    ? /*@__PURE__*/ createComponent<MyListItemElement, MyListItemEvents>({
+        tagName: 'my-list-item',
+        elementClass: MyListItemElement,
+        // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+        react: React,
+        events: {} as MyListItemEvents,
+        defineCustomElement: defineMyListItem
+    })
+    : /*@__PURE__*/ createSSRComponent<MyListItemElement, MyListItemEvents>({
+        tagName: 'my-list-item',
+        properties: {},
+        hydrateModule: import('component-library/hydrate')
+    });
+
 type MyPopoverEvents = {
     onMyPopoverDidPresent: EventName<CustomEvent<void>>,
     onMyPopoverWillPresent: EventName<CustomEvent<void>>,
@@ -295,5 +333,39 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = typ
             disabled: 'disabled',
             value: 'value'
         },
+        hydrateModule: import('component-library/hydrate')
+    });
+
+type MyToggleEvents = NonNullable<unknown>;
+
+export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents> = typeof window !== 'undefined'
+    ? /*@__PURE__*/ createComponent<MyToggleElement, MyToggleEvents>({
+        tagName: 'my-toggle',
+        elementClass: MyToggleElement,
+        // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+        react: React,
+        events: {} as MyToggleEvents,
+        defineCustomElement: defineMyToggle
+    })
+    : /*@__PURE__*/ createSSRComponent<MyToggleElement, MyToggleEvents>({
+        tagName: 'my-toggle',
+        properties: {},
+        hydrateModule: import('component-library/hydrate')
+    });
+
+type MyToggleContentEvents = NonNullable<unknown>;
+
+export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyToggleContentEvents> = typeof window !== 'undefined'
+    ? /*@__PURE__*/ createComponent<MyToggleContentElement, MyToggleContentEvents>({
+        tagName: 'my-toggle-content',
+        elementClass: MyToggleContentElement,
+        // @ts-ignore - React type of Stencil Output Target may differ from the React version used in the Nuxt.js project, this can be ignored.
+        react: React,
+        events: {} as MyToggleContentEvents,
+        defineCustomElement: defineMyToggleContent
+    })
+    : /*@__PURE__*/ createSSRComponent<MyToggleContentElement, MyToggleContentEvents>({
+        tagName: 'my-toggle-content',
+        properties: { visible: 'visible' },
         hydrateModule: import('component-library/hydrate')
     });

--- a/example-project/next-app/src/app/components.ts
+++ b/example-project/next-app/src/app/components.ts
@@ -6,4 +6,4 @@
  */
 
 /* eslint-disable */
-export { MyButton, MyCheckbox, MyComponent, MyInput, MyPopover, MyRadio, MyRadioGroup, MyRange } from "./components.server";
+export { MyButton, MyCheckbox, MyComponent, MyInput, MyList, MyListItem, MyPopover, MyRadio, MyRadioGroup, MyRange, MyToggle, MyToggleContent } from "./components.server";

--- a/example-project/next-app/src/app/dsd/[component]/page.tsx
+++ b/example-project/next-app/src/app/dsd/[component]/page.tsx
@@ -1,0 +1,33 @@
+import { MyButton, MyList, MyListItem } from '../../components';
+import { PureReactComponent } from '../../PureReactComponent/PureReactComponent';
+import { ToggleableContent } from '../../ToggleableContent/ToggleableContent';
+
+export default async function Page({ params }: { params: Promise<{ component: string }> }) {
+  const { component } = await params;
+
+  switch (component) {
+    case 'simple':
+      return <MyButton href="#">Test</MyButton>;
+    case 'nested':
+      return (
+        <MyList>
+          <MyListItem>Item 1</MyListItem>
+          <MyListItem>Item 2</MyListItem>
+          <MyListItem>Item 3</MyListItem>
+        </MyList>
+      );
+    case 'nested-with-react':
+      return (
+        <MyList>
+          <MyListItem>
+            <PureReactComponent />
+          </MyListItem>
+        </MyList>
+      );
+    case 'complex-use-client':
+      // contains a lazy-loaded component and a context provider
+      return <ToggleableContent />;
+    default:
+      return 'Unknown component';
+  }
+}

--- a/example-project/next-app/src/app/layout.tsx
+++ b/example-project/next-app/src/app/layout.tsx
@@ -13,7 +13,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <main className="flex min-h-screen flex-col items-center justify-between p-24">
+          {children}
+        </main>
+      </body>
     </html>
   );
 }

--- a/example-project/next-app/src/app/page.tsx
+++ b/example-project/next-app/src/app/page.tsx
@@ -1,10 +1,11 @@
-import Input from './Input/Input';
 import Button from './Button/Button';
-import { MyComponent, MyRange, MyRadioGroup } from './components';
+import { MyComponent, MyRadioGroup, MyRange } from './components';
+import Input from './Input/Input';
+import { ToggleableContent } from './ToggleableContent/ToggleableContent';
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+    <>
       <Input />
       <hr />
       <Button />
@@ -23,6 +24,7 @@ export default function Home() {
         <input type="radio" name="myRadioGroup" value="two" />
         <input type="radio" name="myRadioGroup" value="three" />
       </MyRadioGroup>
-    </main>
+      <ToggleableContent />
+    </>
   );
 }

--- a/example-project/next-app/test/specs/__snapshots__/dsd.e2e.mts.snap
+++ b/example-project/next-app/test/specs/__snapshots__/dsd.e2e.mts.snap
@@ -1,6 +1,6 @@
 // Snapshot v1
 
-exports[`Declarative Shadow DOM > should render DSD of 'complex-use-client' correctly 1`] = `
+exports[`Static Declarative Shadow DOM (DSD) > should render DSD of 'complex-use-client' correctly 1`] = `
 "<my-toggle class="hydrated" s-id="47" suppresshydrationwarning="true"
   ><template shadowrootmode="open"
     ><!--r.X--><button c-id="X.0.0.0">
@@ -82,7 +82,7 @@ exports[`Declarative Shadow DOM > should render DSD of 'complex-use-client' corr
 "
 `;
 
-exports[`Declarative Shadow DOM > should render DSD of 'nested' correctly 1`] = `
+exports[`Static Declarative Shadow DOM (DSD) > should render DSD of 'nested' correctly 1`] = `
 "<my-list class="hydrated" s-id="27" suppresshydrationwarning="true"
   ><template shadowrootmode="open"
     ><!--r.X-->
@@ -111,7 +111,7 @@ exports[`Declarative Shadow DOM > should render DSD of 'nested' correctly 1`] = 
 "
 `;
 
-exports[`Declarative Shadow DOM > should render DSD of 'nested-with-react' correctly 1`] = `
+exports[`Static Declarative Shadow DOM (DSD) > should render DSD of 'nested-with-react' correctly 1`] = `
 "<my-list class="hydrated" s-id="33" suppresshydrationwarning="true"
   ><template shadowrootmode="open"
     ><!--r.X-->
@@ -144,7 +144,7 @@ exports[`Declarative Shadow DOM > should render DSD of 'nested-with-react' corre
 "
 `;
 
-exports[`Declarative Shadow DOM > should render DSD of 'simple' correctly 1`] = `
+exports[`Static Declarative Shadow DOM (DSD) > should render DSD of 'simple' correctly 1`] = `
 "<my-button
   class="button button-solid hydrated my-activatable my-focusable"
   href="#"

--- a/example-project/next-app/test/specs/__snapshots__/dsd.e2e.mts.snap
+++ b/example-project/next-app/test/specs/__snapshots__/dsd.e2e.mts.snap
@@ -1,0 +1,164 @@
+// Snapshot v1
+
+exports[`Declarative Shadow DOM > should render DSD of 'complex-use-client' correctly 1`] = `
+"<my-toggle class="hydrated" s-id="47" suppresshydrationwarning="true"
+  ><template shadowrootmode="open"
+    ><!--r.X--><button c-id="X.0.0.0">
+      <!--t.X.1.1.0-->
+      Open Modal
+    </button>
+    <my-toggle-content c-id="X.2.0.1" class="hydrated" s-id="48">
+      <template shadowrootmode="open"></template>
+      <!--r.X-->
+      <slot c-id="X.3.1.0"></slot> </my-toggle-content
+  ></template>
+  <div
+    style="
+      padding: 1rem;
+      border: 1px solid black;
+      border-radius: 0.5rem;
+      margin: 1rem;
+    "
+  >
+    <p style="margin-bottom: 0.5rem">Pure React Component</p>
+    <button
+      style="border: 1px solid black; padding: 0.5rem; border-radius: 0.5rem"
+    >
+      Click me (Clicked:
+      <!-- -->0<!-- -->)
+    </button>
+  </div>
+  <div
+    style="
+      border: 1px red solid;
+      padding: 1rem;
+      margin: 1rem;
+      border-radius: 0.5rem;
+    "
+  >
+    <p style="margin-bottom: 0.5rem">
+      LazyLoadedComponent with theme:
+      <!-- -->light
+    </p>
+    <div style="display: flex; gap: 1rem; align-items: center">
+      <button
+        style="border: 1px solid black; padding: 0.5rem; border-radius: 0.5rem"
+      >
+        -</button
+      ><span>0</span
+      ><button
+        style="border: 1px solid black; padding: 0.5rem; border-radius: 0.5rem"
+      >
+        +
+      </button>
+    </div>
+  </div>
+  <my-list class="hydrated" s-id="52" suppresshydrationwarning="true"
+    ><template shadowrootmode="open"
+      ><!--r.X-->
+      <ul c-id="X.0.0.0">
+        <slot c-id="X.1.1.0"></slot></ul></template
+    ><my-list-item class="hydrated" s-id="56" suppresshydrationwarning="true"
+      ><template shadowrootmode="open"
+        ><!--r.X-->
+        <li c-id="X.0.0.0">
+          <slot c-id="X.1.1.0"></slot></li></template
+      >Item 1</my-list-item
+    ><my-list-item class="hydrated" s-id="57" suppresshydrationwarning="true"
+      ><template shadowrootmode="open"
+        ><!--r.X-->
+        <li c-id="X.0.0.0">
+          <slot c-id="X.1.1.0"></slot></li></template
+      >Item 2</my-list-item
+    ><my-list-item class="hydrated" s-id="58" suppresshydrationwarning="true"
+      ><template shadowrootmode="open"
+        ><!--r.X-->
+        <li c-id="X.0.0.0">
+          <slot c-id="X.1.1.0"></slot></li></template
+      >Item 3</my-list-item
+    ></my-list
+  ></my-toggle
+>
+"
+`;
+
+exports[`Declarative Shadow DOM > should render DSD of 'nested' correctly 1`] = `
+"<my-list class="hydrated" s-id="27" suppresshydrationwarning="true"
+  ><template shadowrootmode="open"
+    ><!--r.X-->
+    <ul c-id="X.0.0.0">
+      <slot c-id="X.1.1.0"></slot></ul></template
+  ><my-list-item class="hydrated" s-id="28" suppresshydrationwarning="true"
+    ><template shadowrootmode="open"
+      ><!--r.X-->
+      <li c-id="X.0.0.0">
+        <slot c-id="X.1.1.0"></slot></li></template
+    >Item 1</my-list-item
+  ><my-list-item class="hydrated" s-id="29" suppresshydrationwarning="true"
+    ><template shadowrootmode="open"
+      ><!--r.X-->
+      <li c-id="X.0.0.0">
+        <slot c-id="X.1.1.0"></slot></li></template
+    >Item 2</my-list-item
+  ><my-list-item class="hydrated" s-id="30" suppresshydrationwarning="true"
+    ><template shadowrootmode="open"
+      ><!--r.X-->
+      <li c-id="X.0.0.0">
+        <slot c-id="X.1.1.0"></slot></li></template
+    >Item 3</my-list-item
+  ></my-list
+>
+"
+`;
+
+exports[`Declarative Shadow DOM > should render DSD of 'nested-with-react' correctly 1`] = `
+"<my-list class="hydrated" s-id="33" suppresshydrationwarning="true"
+  ><template shadowrootmode="open"
+    ><!--r.X-->
+    <ul c-id="X.0.0.0">
+      <slot c-id="X.1.1.0"></slot></ul></template
+  ><my-list-item class="hydrated" s-id="34" suppresshydrationwarning="true"
+    ><template shadowrootmode="open"
+      ><!--r.X-->
+      <li c-id="X.0.0.0">
+        <slot c-id="X.1.1.0"></slot></li
+    ></template>
+    <div
+      style="
+        padding: 1rem;
+        border: 1px solid black;
+        border-radius: 0.5rem;
+        margin: 1rem;
+      "
+    >
+      <p style="margin-bottom: 0.5rem">Pure React Component</p>
+      <button
+        style="border: 1px solid black; padding: 0.5rem; border-radius: 0.5rem"
+      >
+        Click me (Clicked:
+        <!-- -->0<!-- -->)
+      </button>
+    </div></my-list-item
+  ></my-list
+>
+"
+`;
+
+exports[`Declarative Shadow DOM > should render DSD of 'simple' correctly 1`] = `
+"<my-button
+  class="button button-solid hydrated my-activatable my-focusable"
+  href="#"
+  s-id="22"
+  suppresshydrationwarning="true"
+  ><template shadowrootmode="open"
+    ><!--r.X--><a c-id="X.0.0.0" class="button-native" href="#">
+      <span c-id="X.1.1.0" class="button-inner">
+        <slot c-id="X.2.2.0" name="icon-only"></slot>
+        <slot c-id="X.3.2.1" name="start"></slot>
+        <slot c-id="X.4.2.2"></slot>
+        <slot c-id="X.5.2.3" name="end"></slot>
+      </span> </a></template
+  >Test</my-button
+>
+"
+`;

--- a/example-project/next-app/test/specs/dsd.e2e.mts
+++ b/example-project/next-app/test/specs/dsd.e2e.mts
@@ -1,0 +1,23 @@
+/// <reference types="@wdio/mocha-framework" />
+/// <reference types="webdriverio" />
+import { browser, expect } from '@wdio/globals';
+import prettier from 'prettier';
+
+describe('Static Declarative Shadow DOM (DSD)', () => {
+  for (const component of ['simple', 'nested', 'nested-with-react', 'complex-use-client']) {
+    it(`should render DSD of '${component}' correctly`, async () => {
+      await browser.url(`/dsd/${component}`);
+      const page = await fetch(await browser.getUrl());
+      const rawContent = await page.text();
+      const componentHtml = rawContent.match(/<main[^>]*>([\s\S]*)<\/main>/)?.[1] ?? '';
+      const formattedHtml = await prettier.format(componentHtml, { parser: 'html' });
+      // Depeneding on the order the components are first rendered, the ids might be different
+      const sanitizedHtml = formattedHtml
+        .replaceAll(/r\.\d+/g, 'r.X')
+        .replaceAll(/t\.\d+/g, 't.X')
+        .replaceAll(/c-id="\d+/g, 'c-id="X');
+
+      expect(sanitizedHtml).toMatchSnapshot();
+    });
+  }
+});

--- a/example-project/next-app/test/specs/test.e2e.mts
+++ b/example-project/next-app/test/specs/test.e2e.mts
@@ -1,15 +1,10 @@
 /// <reference types="@wdio/mocha-framework" />
 /// <reference types="webdriverio" />
-import { expect, $, browser } from '@wdio/globals';
+import { $, browser, expect } from '@wdio/globals';
 
 describe('Stencil NextJS Integration', () => {
   before(() => browser.url('/'));
 
-  /**
-   * ToDo(Christian): enhance the test by fetching the body response instead of the page source
-   *                  which doesn't contain the template contents. This feature is currently not
-   *                  available in WebDriver.
-   */
   it('should have hydrated the page', async () => {
     const source = await browser.getPageSource();
     // serializes component children
@@ -39,5 +34,5 @@ describe('Stencil NextJS Integration', () => {
 
   it('should propagate custom element styles', async () => {
     await expect($('my-component')).toHaveStyle({ backgroundColor: 'rgba(255,0,0,1)' });
-  })
+  });
 });

--- a/packages/react/src/react/ssr.tsx
+++ b/packages/react/src/react/ssr.tsx
@@ -34,7 +34,11 @@ type LazyComponent<T, P> = {
   _init: (payload: P) => T;
 };
 
-type ReactNodeExtended = ReactNode | Component<any, any, any> | LazyComponent<any, any>;
+type ReactNodeExtended =
+  | ReactNode
+  | Component<any, any, any>
+  | LazyComponent<any, any>
+  | ((props: any, deprecatedLegacyContext?: any) => ReactNode);
 
 /**
  * returns true if the value is a primitive, e.g. string, number, boolean
@@ -57,14 +61,6 @@ const isEmpty = (value: unknown): value is null | undefined => value === null ||
  * @returns true if the value is iterable, false otherwise
  */
 const isIterable = (value: unknown): value is Iterable<ReactNode> => Array.isArray(value);
-
-/**
- * returns true if the value is a promise
- * @param value - the value to check
- * @returns true if the value is a promise, false otherwise
- */
-const isPromise = (value: unknown): value is Promise<any> =>
-  !!value && typeof value === 'object' && 'then' in value && typeof value.then === 'function';
 
 /**
  * returns true if the value is a JSX class element constructor
@@ -139,8 +135,15 @@ export const createComponentForServerSideRendering = <I extends HTMLElement, E e
     let serializedChildren = '';
     const toSerialize = `<${options.tagName}${stringProps} suppressHydrationWarning="true">`;
     try {
+      const originalConsoleError = console.error;
+      // Ignore potential console errors during serialization
+      // as they are not relevant for the user and may cause confusion
+      if (!process.env.STENCIL_SSR_DEBUG) {
+        console.error = () => {};
+      }
       const awaitedChildren = await resolveComponentTypes(children);
       serializedChildren = ReactDOMServer.renderToString(awaitedChildren);
+      console.error = originalConsoleError;
     } catch (err: unknown) {
       /**
        * if rendering the light DOM fails, we log a warning and continue to render the component
@@ -296,50 +299,49 @@ async function resolveComponentTypes(children: ReactNode): Promise<ReactNode> {
 
       const { type, props } = child;
 
-      let resolvedType: ReactNodeExtended = null;
-      if (typeof type === 'string') {
-        // Child is a primitive element like 'div'
-        resolvedType = type;
-      } else if (isJSXClassElementConstructor(type)) {
-        // Child is a Class Component
-        const instance = new type(props);
-        resolvedType = instance.render ? instance.render() : instance;
-      } else {
-        // Child is a Function Component because React Server
-        // Components can be a Promise we need to await it
-        resolvedType = await type(props);
-      }
-
-      // `resolvedType` can have a `type` property which is the actual component
-      if (!isEmpty(resolvedType) && !isPrimitive(resolvedType) && 'type' in resolvedType) {
-        resolvedType = resolvedType.type as any;
-      }
-
-      // If the resolved type is a lazy component we need to resolve it
-      if (isLazyExoticComponent(resolvedType)) {
-        if (isPromise(resolvedType._payload)) {
-          resolvedType = { ...resolvedType, _payload: await resolvedType._payload };
-        }
-        if (typeof resolvedType._payload === 'function') {
-          resolvedType = {
-            ...resolvedType,
-            $$typeof: Symbol('react.element'),
-            _payload: await resolvedType._payload(props),
-          };
-          if (typeof resolvedType._payload.type === 'function') {
-            return resolvedType._payload.type(props);
-          }
-        }
-      }
-
       return {
         ...child,
         props: {
           ...props,
           children: await resolveComponentTypes(props.children),
         },
-        type: resolvedType,
-      };
+        type: await resolveType(type, props),
+      } as ReactNode;
     })
   );
 }
+
+// Resolve the component type to a primitive element type
+const resolveType = async (type: string | React.JSXElementConstructor<any>, props: any): Promise<ReactNodeExtended> => {
+  let resolvedType: ReactNodeExtended = null;
+
+  if (typeof type === 'string') {
+    // Child is a primitive element like 'div'
+    return type;
+  } else if (isJSXClassElementConstructor(type)) {
+    // Child is a Class Component
+    const instance = new type(props);
+    resolvedType = instance.render ? instance.render() : instance;
+  } else if (isLazyExoticComponent(type)) {
+    // Handle React Lazy Component
+    // https://github.com/facebook/react/blob/main/packages/react/src/ReactLazy.js
+    const payload = type._payload;
+    const { deault: lazyComponet } =
+      payload._status === -1 // Uninitialized = -1 so we need resolve the promise
+        ? await payload._result()
+        : payload._result;
+    // Now resolve the actual component type of the lazy component
+    resolvedType = await resolveType(lazyComponet, props);
+  } else if (typeof type !== 'object') {
+    // Child is a Function Component because React Server
+    // Components can be a Promise we need to await it
+    resolvedType = await type(props);
+  }
+
+  // Recursively resolve the component type until we have a primitive element type
+  if (!isEmpty(resolvedType) && !isPrimitive(resolvedType) && 'type' in resolvedType) {
+    resolvedType = await resolveType(resolvedType.type, props);
+  }
+
+  return resolvedType;
+};


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There are still some cases where resolving the correct types fails, which results in warnings and, occasionally, incorrectly rendered content.

Issue URL: #561 

## What is the new behavior?

Resolve component types correctly also for nested and lazy components.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

I’ve added some new components and new tests to the Next.js example project to verify that the generated HTML includes the expected Declarative Shadow DOM.
