### PR TITLE
Publish: @stencil/react-output-target v0.8.2

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/react-output-target",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "React output target for @stencil/core components.",
   "main": "./dist/react-output-target.js",
   "module": "./dist/react-output-target.js",


### PR DESCRIPTION
This patch bumps versions for:

- `@stencil/react-output-target` to `v0.8.2`

# Changes

Some general project changes include:

## React Output Target

- https://github.com/ionic-team/stencil-ds-output-targets/pull/594
- https://github.com/ionic-team/stencil-ds-output-targets/pull/583
