### PR TITLE
Publish: @stencil/vue-output-target v0.9.3

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Vue output target for @stencil/core components.",
   "author": "Ionic Team",
   "homepage": "https://stenciljs.com/",


### PR DESCRIPTION
This patch bumps versions for:

- `@stencil/vue-output-target` to `v0.9.3`

# Changes

Some general project changes include:

## Vue Output Target

- https://github.com/ionic-team/stencil-ds-output-targets/pull/606
