### PR TITLE
Fix/616 vue custom event listeners

### DIFF
--- a/example-project/vue-app/src/App.vue
+++ b/example-project/vue-app/src/App.vue
@@ -2,6 +2,13 @@
 import HelloWorld from './components/HelloWorld.vue'
 // @ts-ignore
 import Input from './components/Input.vue'
+import { MyComponent } from 'component-library-vue'
+import { ref } from 'vue'
+
+const isClicked = ref(false)
+const handleCustomEvent = () => {
+  isClicked.value = true
+}
 </script>
 
 <template>
@@ -14,6 +21,8 @@ import Input from './components/Input.vue'
     </a>
   </div>
   <HelloWorld msg="Vite + Vue" />
+  <MyComponent @myCustomEvent="handleCustomEvent" />
+  <p data-testid="mycomponent-click" v-show="isClicked">MyComponent was clicked</p>
   <Input />
 </template>
 

--- a/example-project/vue-app/src/components/Input.vue
+++ b/example-project/vue-app/src/components/Input.vue
@@ -8,24 +8,10 @@ export default defineComponent({
     MyInput,
   },
   setup() {
-    const inputEvent = ref('');
-    const changeEvent = ref('');
-
-    const handleInput = (ev) => {
-      console.log('handleInput', ev.target.value);
-      inputEvent.value = ev.target.value;
-    };
-
-    const handleChange = (ev) => {
-      console.log('handleChange', ev.target.value);
-      changeEvent.value = ev.detail.value;
-    };
+    const inputValue = ref('');
 
     return {
-      inputEvent,
-      changeEvent,
-      handleInput,
-      handleChange,
+      inputValue,
     };
   },
 });
@@ -40,13 +26,11 @@ export default defineComponent({
 <template>
   <div>
     <MyInput
-      @myInput="handleInput"
-      @myChange="handleChange"
+      v-model="inputValue"
     >
     </MyInput>
     <div class="inputResult">
-      <p>Input Event: {{ inputEvent }}</p>
-      <p>Change Event: {{ changeEvent }}</p>
+      <p>Input Value: {{ inputValue }}</p>
     </div>
   </div>
 </template>

--- a/example-project/vue-app/src/components/Input.vue
+++ b/example-project/vue-app/src/components/Input.vue
@@ -9,9 +9,17 @@ export default defineComponent({
   },
   setup() {
     const inputValue = ref('');
+    const changeEvent = ref('');
+
+    const handleChange = (ev) => {
+      console.log('handleChange', ev.target.value);
+      changeEvent.value = ev.detail.value;
+    };
 
     return {
       inputValue,
+      changeEvent,
+      handleChange
     };
   },
 });
@@ -27,10 +35,12 @@ export default defineComponent({
   <div>
     <MyInput
       v-model="inputValue"
+      @myChange="handleChange"
     >
     </MyInput>
     <div class="inputResult">
-      <p>Input Value: {{ inputValue }}</p>
+      <p>Input v-model: {{ inputValue }}</p>
+      <p>Change Event: {{ changeEvent }}</p>
     </div>
   </div>
 </template>

--- a/example-project/vue-app/tests/test.e2e.ts
+++ b/example-project/vue-app/tests/test.e2e.ts
@@ -7,9 +7,13 @@ describe('Stencil Vue Integration', () => {
 
   it('should allow to interact with input element', async () => {
     await $('my-input').$('input').setValue('Hello World');
-    await expect(await $$('.inputResult p').map((p) => p.getText())).toEqual([
-      'Input Event: Hello World',
-      'Change Event: Hello World'
-    ]);
+    await expect(await $('.inputResult p').getText()).toEqual(
+      'Input Value: Hello World',
+    );
+  });
+
+  it('should listen to custom events', async () => {
+    await $('my-component').$('div').click();
+    await expect(await $('[data-testid="mycomponent-click"]').getText()).toEqual('MyComponent was clicked');
   });
 });

--- a/example-project/vue-app/tests/test.e2e.ts
+++ b/example-project/vue-app/tests/test.e2e.ts
@@ -7,9 +7,10 @@ describe('Stencil Vue Integration', () => {
 
   it('should allow to interact with input element', async () => {
     await $('my-input').$('input').setValue('Hello World');
-    await expect(await $('.inputResult p').getText()).toEqual(
-      'Input Value: Hello World',
-    );
+    await expect(await $$('.inputResult p').map((p) => p.getText())).toEqual([
+      'Input v-model: Hello World',
+      'Change Event: Hello World'
+    ]);
   });
 
   it('should listen to custom events', async () => {

--- a/packages/vue/src/runtime.ts
+++ b/packages/vue/src/runtime.ts
@@ -107,7 +107,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
       created: (el: HTMLElement) => {
         const eventsNames = Array.isArray(modelUpdateEvent) ? modelUpdateEvent : [modelUpdateEvent];
         eventsNames.forEach((eventName: string) => {
-          el.addEventListener(eventName.toLowerCase(), (e: Event) => {
+          el.addEventListener(eventName, (e: Event) => {
             /**
              * Only update the v-model binding if the event's target is the element we are
              * listening on. For example, Component A could emit ionChange, but it could also

--- a/packages/vue/src/runtime.ts
+++ b/packages/vue/src/runtime.ts
@@ -1,4 +1,4 @@
-import { defineComponent, getCurrentInstance, h, inject, ref, Ref, withDirectives } from 'vue';
+import { defineComponent, getCurrentInstance, h, inject, onMounted, ref, Ref, withDirectives } from 'vue';
 
 export { defineStencilSSRComponent } from './ssr';
 export interface InputProps<T> {
@@ -81,6 +81,18 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     const containerRef = ref<HTMLElement>();
     const classes = new Set(getComponentClasses(attrs.class));
 
+    onMounted(() => {
+      /**
+       * we register the event emmiter for @Event definitions
+       * so we can use @event
+       */
+      emitProps.forEach((eventName: string) => {
+        containerRef.value!.addEventListener(eventName, (e: Event) => {
+          emit(eventName, e);
+        });
+      });
+    });
+
     /**
      * This directive is responsible for updating any reactive
      * reference associated with v-model on the component.
@@ -107,16 +119,6 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
               modelPropValue = (e?.target as any)[modelProp];
               emit(UPDATE_VALUE_EVENT, modelPropValue);
             }
-          });
-        });
-
-        /**
-         * we register the event emmiter for @Event definitions
-         * so we can use @event
-         */
-        emitProps.forEach((eventName: string) => {
-          el.addEventListener(eventName, (e: Event) => {
-            emit(eventName, e);
           });
         });
       },


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: https://github.com/ionic-team/stencil-ds-output-targets/issues/616

In [example-project/vue-app/src/components/Input.vue](https://github.com/andrewbeng89/stencil-ds-output-targets/blob/fix/616-vue-custom-event-listeners/example-project/vue-app/src/components/Input.vue) `v-model` binding and `@myChange` handling are not behaving as expected:

```Vue
<template>
  <div>
    <MyInput
      v-model="inputValue"
      @myChange="handleChange"
    >
    </MyInput>
    <div class="inputResult">
      <p>Input v-model: {{ inputValue }}</p>
      <p>Change Event: {{ changeEvent }}</p>
    </div>
  </div>
</template>
```
The corresponding [E2E test](https://github.com/andrewbeng89/stencil-ds-output-targets/blob/fix/616-vue-custom-event-listeners/example-project/vue-app/tests/test.e2e.ts) for this behaviour should pass:

```js
  it('should allow to interact with input element', async () => {
    await $('my-input').$('input').setValue('Hello World');
    await expect(await $$('.inputResult p').map((p) => p.getText())).toEqual([
      'Input v-model: Hello World',
      'Change Event: Hello World'
    ]);
  });
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Any Vue out component with an emitted `@Event customEvent` defined in Stencil should handle `@customEvent` as expected (with or without [`v-model` defined](https://stenciljs.com/docs/vue#componentmodels))
- If defined in `stencil.config.ts`, `v-model` bindings should work as expected
- Tests:
  - with `v-model`: https://github.com/andrewbeng89/stencil-ds-output-targets/blob/fix/616-vue-custom-event-listeners/example-project/vue-app/tests/test.e2e.ts#L8
  - without `v-model`: https://github.com/andrewbeng89/stencil-ds-output-targets/blob/fix/616-vue-custom-event-listeners/example-project/vue-app/tests/test.e2e.ts#L16

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

