### PR TITLE
Publish: @stencil/vue-output-target v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## @stencil/vue-output-target@0.9.5 (2025-02-20)
+
+#### :bug: Bug Fix
+
+- `vue-output-target`
+  - [#617](https://github.com/ionic-team/stencil-ds-output-targets/pull/617) Fix vue output target ([@andrewbeng89](https://github.com/andrewbeng89))
+
 ## @stencil/vue-output-target@0.0.1 (2020-06-26)
 
 #### :rocket: Enhancement

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/vue-output-target",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Vue output target for @stencil/core components.",
   "author": "Ionic Team",
   "homepage": "https://stenciljs.com/",


### PR DESCRIPTION
## @stencil/vue-output-target@0.9.5 (2025-02-20)

#### :bug: Bug Fix

- `vue-output-target`
  - [#617](https://github.com/ionic-team/stencil-ds-output-targets/pull/617) Fix vue output target ([@andrewbeng89](https://github.com/andrewbeng89))
